### PR TITLE
bugfix crashing when attempting to auth with no internet

### DIFF
--- a/android/src/main/kotlin/com/sahha/flutter/SahhaFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/sahha/flutter/SahhaFlutterPlugin.kt
@@ -152,7 +152,10 @@ class SahhaFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
     if (appId != null && appSecret != null && externalId != null) {
       Sahha.authenticate(appId, appSecret, externalId) { error, success ->
-        if(!success) result.error("Sahha Error", error, null)
+        if(!success) {
+          result.error("Sahha Error", error, null)
+          return@authenticate
+        }
         result.success(success)
         return@authenticate
       }


### PR DESCRIPTION
the app couldn't handle returning two `result` objects.

in this case it was returning the error and then attempting to return the `success` bool as well which caused an exception

exiting the method after just the error `result` fixed this