### PR TITLE
fix: update to 1.3.9-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.3.9-beta.4
+
+### Added
+
+-
+
+### Changed
+
+- Updated IOS to 1.3.9-beta.4 check release notes https://github.com/sahha-ai/sahha-ios/releases
+- Updated Android to 1.3.9-beta.4 check release notes https://github.com/sahha-ai/sahha-android-sdk/releases
+
+### Fixed
+
+- Fixed an Android crash in host apps that don't include a `res/drawable/notification` icon — the background collection and sync notifications now fall back to a bundled Sahha icon instead of crashing with `Invalid notification (no valid small icon)`.
+
+---
+
 ## 1.3.9-beta.2
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ Only include the sensor permissions required by your project, what is declared h
 
 You must be able to justify reasons behind requiring the sensor permissions, [these](https://docs.sahha.ai/docs/data-flow/sdk/app-store-submission/google-play-store#data-type-justifications) justifications may be used to clearly articulate the reasoning behind your required sensor permissions.
 
+#### Background data collection notification
+
+On Android, Sahha collects sensor data using a foreground service, which Android requires to show a persistent notification while it runs. The notification's small icon is resolved from a drawable in your app's `res/drawable/` folder:
+
+- By default Sahha looks for a drawable named `notification` — e.g. `android/app/src/main/res/drawable/notification.png`.
+- To use a different drawable, pass its name via `notificationSettings` when you call `configure(...)`:
+
+```dart
+SahhaFlutter.configure(
+  environment: SahhaEnvironment.production,
+  notificationSettings: {
+    'icon': 'my_notification_icon', // name of a drawable in res/drawable/
+    'title': 'My App',
+    'shortDescription': 'Collecting health insights',
+  },
+);
+```
+
+If the named drawable cannot be found, Sahha falls back to a bundled default icon so your app keeps running. Adding your own `notification` drawable (or passing a valid `icon` name) is recommended so the persistent notification matches your branding.
+
 ### Apple iOS
 
 #### Enable HealthKit

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,5 +54,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.google.code.gson:gson:2.13.2"
-    implementation "ai.sahha.android:sahha-api:1.3.9-beta.2"
+    implementation "ai.sahha.android:sahha-api:1.3.9-beta.4"
 }

--- a/android/src/main/kotlin/com/sahha/flutter/SahhaFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/sahha/flutter/SahhaFlutterPlugin.kt
@@ -194,11 +194,16 @@ class SahhaFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 framework = SahhaFramework.FLUTTER,
                 environment = SahhaEnvironment.valueOf(environment.uppercase()),
                 notificationSettings = SahhaNotificationConfiguration(
+                    // Fall back to the SDK's bundled icon (ic_sahha_no_bg) when the host app ships
+                    // no matching drawable. Passing 0 here persists an invalid icon id that later
+                    // reaches Notification.Builder.setSmallIcon(), throwing
+                    // "Invalid notification (no valid small icon)" and crashing the host app —
+                    // including the headless background sync worker, which reads the same id.
                     iconResourceId =
                         stringToDrawableResource(
                             context,
-                            notificationSettings["icon"] ?:"notification"
-                        ) ?: 0,
+                            notificationSettings["icon"] ?: "notification"
+                        ) ?: SahhaNotificationConfiguration.DEFAULT.iconResourceId,
                     title = notificationSettings["title"] ?: "Title",
                     shortDescription = notificationSettings["shortDescription"] ?: "Short description"
                 )
@@ -757,9 +762,13 @@ class SahhaFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
     }
 
+    // Resolves a host-app drawable by name to its resource id, or null when the host app ships no
+    // such drawable. getIdentifier() returns 0 (not an exception) when nothing matches, so we map
+    // that to null — callers must never pass 0 to setSmallIcon(), which crashes the host app.
     fun stringToDrawableResource(context: Context, iconString: String?): Int? {
         return try {
-            context.resources.getIdentifier(iconString, "drawable", context.packageName)
+            val resourceId = context.resources.getIdentifier(iconString, "drawable", context.packageName)
+            if (resourceId != 0) resourceId else null
         } catch (e: Exception) {
             null
         }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Sahha (1.3.9-beta.2)
-  - sahha_flutter (1.3.9-beta.2):
+  - Sahha (1.3.9-beta.4)
+  - sahha_flutter (1.3.9-beta.4):
     - Flutter
-    - Sahha (= 1.3.9-beta.2)
+    - Sahha (= 1.3.9-beta.4)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  Sahha: 93107c02edf64e5e66a4afc682342354e124733d
-  sahha_flutter: 5e3715590df3dbf7876ecb7168bcb24d80cd8cc6
+  Sahha: a3f8ae02dbb5c4dff310d52bc2af6e4d4c8a0503
+  sahha_flutter: 80e2b2fd09b7afbf08216d1ab31fcb2a9e9b3365
 
 PODFILE CHECKSUM: 3e9409b67ba5801961716bfaf81c42bfee93d9a9
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -156,10 +156,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   nested:
     dependency: transitive
     description:
@@ -230,7 +230,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.9-beta.2"
+    version: "1.3.9-beta.4"
   selectpicker:
     dependency: "direct main"
     description:
@@ -344,10 +344,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:

--- a/ios/sahha_flutter.podspec
+++ b/ios/sahha_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sahha_flutter'
-  s.version          = '1.3.9-beta.2'
+  s.version          = '1.3.9-beta.4'
   s.summary          = 'Sahha Flutter SDK'
   s.description      = 'The Sahha SDK provides a convenient way for Flutter apps to connect to the Sahha API.'
   s.homepage         = 'https://sahha.ai'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Sahha', '1.3.9-beta.2'
+  s.dependency 'Sahha', '1.3.9-beta.4'
   s.platform = :ios, '15.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sahha_flutter
 description: Sahha Flutter Plugin
-version: 1.3.9-beta.2
+version: 1.3.9-beta.4
 homepage: https://sahha.ai
 repository: https://github.com/sahha-ai/sahha_flutter
 


### PR DESCRIPTION
## 1.3.9-beta.4

### Added

-

### Changed

- Updated iOS to 1.3.9-beta.4 — see release notes: https://github.com/sahha-ai/sahha-ios/releases
- Updated Android to 1.3.9-beta.4 — see release notes: https://github.com/sahha-ai/sahha-android-sdk/releases

### Fixed

- Android crash in host apps that don't include a `res/drawable/notification` icon — background collection and sync notifications now fall back to a bundled Sahha icon instead of crashing with `Invalid notification (no valid small icon)`.
