### PR TITLE
fix: update to 1.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.3.9
+
+### Added
+
+-
+
+### Changed
+
+- Updated IOS to 1.3.9 check release notes https://github.com/sahha-ai/sahha-ios/releases
+- Updated Android to 1.3.9 check release notes https://github.com/sahha-ai/sahha-android-sdk/releases
+
+### Fixed
+
+- Fixed an Android crash in host apps that don't include a `res/drawable/notification` icon — the background collection and sync notifications now fall back to a bundled Sahha icon instead of crashing with `Invalid notification (no valid small icon)`.
+
+---
+
 ## 1.3.9-beta.5
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,5 +54,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.google.code.gson:gson:2.13.2"
-    implementation "ai.sahha.android:sahha-api:1.3.9-beta.5"
+    implementation "ai.sahha.android:sahha-api:1.3.9"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Sahha (1.3.9-beta.5)
-  - sahha_flutter (1.3.9-beta.5):
+  - Sahha (1.3.9)
+  - sahha_flutter (1.3.9):
     - Flutter
-    - Sahha (= 1.3.9-beta.5)
+    - Sahha (= 1.3.9)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  Sahha: 0668158530e539ad83a8fa98d5ce5d2edcf541cb
-  sahha_flutter: 10f8cb4ab1232867793032ffefbe14fdd4f385b6
+  Sahha: 80053864fedde618e438149b9bacd77741887052
+  sahha_flutter: 790a822a8448e12032c5369837e4ca6a77b1de92
 
 PODFILE CHECKSUM: 3e9409b67ba5801961716bfaf81c42bfee93d9a9
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -230,7 +230,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.9-beta.5"
+    version: "1.3.9"
   selectpicker:
     dependency: "direct main"
     description:

--- a/ios/sahha_flutter.podspec
+++ b/ios/sahha_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sahha_flutter'
-  s.version          = '1.3.9-beta.5'
+  s.version          = '1.3.9'
   s.summary          = 'Sahha Flutter SDK'
   s.description      = 'The Sahha SDK provides a convenient way for Flutter apps to connect to the Sahha API.'
   s.homepage         = 'https://sahha.ai'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Sahha', '1.3.9-beta.5'
+  s.dependency 'Sahha', '1.3.9'
   s.platform = :ios, '15.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sahha_flutter
 description: Sahha Flutter Plugin
-version: 1.3.9-beta.5
+version: 1.3.9
 homepage: https://sahha.ai
 repository: https://github.com/sahha-ai/sahha_flutter
 


### PR DESCRIPTION
### Added

-

### Changed

- Updated IOS to 1.3.9 check release notes https://github.com/sahha-ai/sahha-ios/releases
- Updated Android to 1.3.9 check release notes https://github.com/sahha-ai/sahha-android-sdk/releases

### Fixed

- Fixed an Android crash in host apps that don't include a `res/drawable/notification` icon — the background collection and sync notifications now fall back to a bundled Sahha icon instead of crashing with `Invalid notification (no valid small icon)`.
