### PR TITLE
fix: update to 1.4.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Breaking:** renamed `SahhaBiomarkerType.activity_mid_intensity_duration` to `activity_medium_intensity_duration`. The old name was outside the documented vocabulary and silently returned no data.
 - Deprecated `getStats` and `getSamples` — use `getBiomarkers` to read server-processed biomarkers instead.
 - Stat and sample `category` values are now labeled with the sensor's data-log logType: heart rate types report `heart`, blood pressure/glucose report `blood`, oxygen/VO2 max/respiratory rate report `oxygen`, temperature types report `temperature`, and energy/daylight types report `energy`. `vitals` no longer appears.
+- Rebuilt the example app as a full testing harness — biomarker, score, stats and samples query screens with type selectors and date ranges, a checked-list sensor permissions screen, a per-sensor diagnostics screen, and a Material 3 UI.
 - Updated iOS to 1.4.0-beta.1 — check release notes https://github.com/sahha-ai/sahha-ios/releases
 - Updated Android to 1.4.0-beta.1 — check release notes https://github.com/sahha-ai/sahha-android-sdk/releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 1.4.0-beta.1
+
+### Added
+
+- `engagement` biomarker category in `SahhaBiomarkerCategory`.
+
+### Changed
+
+- **Breaking:** `SahhaBiomarkerCategory` now contains exactly the six documented categories (`activity`, `body`, `engagement`, `nutrition`, `sleep`, `vitals`). Removed `characteristic` and `reproductive`, which never returned biomarker data.
+- **Breaking:** renamed `SahhaBiomarkerType.activity_mid_intensity_duration` to `activity_medium_intensity_duration`. The old name was outside the documented vocabulary and silently returned no data.
+- Deprecated `getStats` and `getSamples` — use `getBiomarkers` to read server-processed biomarkers instead.
+- Stat and sample `category` values are now labeled with the sensor's data-log logType: heart rate types report `heart`, blood pressure/glucose report `blood`, oxygen/VO2 max/respiratory rate report `oxygen`, temperature types report `temperature`, and energy/daylight types report `energy`. `vitals` no longer appears.
+- Updated iOS to 1.4.0-beta.1 — check release notes https://github.com/sahha-ai/sahha-ios/releases
+- Updated Android to 1.4.0-beta.1 — check release notes https://github.com/sahha-ai/sahha-android-sdk/releases
+
+### Fixed
+
+- iOS: `enableSensors` callback no longer hangs indefinitely; hardened token refresh and session-expiry handling.
+- Android: `enableSensors` reports sensor status reliably, plus Health Connect read-robustness fixes from the native 1.4.0-beta.1 release.
+
+---
+
 ## 1.3.9
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -707,10 +707,10 @@ enum SahhaScoreType {
 enum SahhaBiomarkerCategory {
   activity,
   body,
-  characteristic,
-  reproductive,
+  engagement,
+  nutrition,
   sleep,
-  vitals
+  vitals,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ enum SahhaBiomarkerType {
   active_hours,
   active_duration,
   activity_low_intensity_duration,
-  activity_mid_intensity_duration,
+  activity_medium_intensity_duration,
   activity_high_intensity_duration,
   activity_sedentary_duration,
   active_energy_burned,

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ static Future<String> getBiomarkers(
 
 **Example usage**:
 ```dart
-    const cateories = [
+    const categories = [
       SahhaBiomarkerCategory.activity,
       SahhaBiomarkerCategory.sleep,
     ];
@@ -453,6 +453,8 @@ static Future<String> getBiomarkers(
 
 ### getStats(...)
 
+> **Deprecated:** Use `getBiomarkers` to read server-processed biomarkers instead.
+
 ```dart
 static Future<String> getStats(
       {required SahhaSensor sensor,
@@ -476,6 +478,8 @@ static Future<String> getStats(
 ---
 
 ### getSamples(...)
+
+> **Deprecated:** Use `getBiomarkers` to read server-processed biomarkers instead.
 
 ```dart
 static Future<String> getSamples(

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,5 +54,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.google.code.gson:gson:2.13.2"
-    implementation "ai.sahha.android:sahha-api:1.3.9"
+    implementation "ai.sahha.android:sahha-api:1.4.0-beta.1"
 }

--- a/android/src/main/kotlin/com/sahha/flutter/SahhaFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/sahha/flutter/SahhaFlutterPlugin.kt
@@ -331,6 +331,27 @@ class SahhaFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             }
         }.toSet()
 
+    // Skips biomarker names the SDK doesn't recognise, matching the iOS bridge.
+    private fun List<String>.toSahhaBiomarkerCategories(): Set<SahhaBiomarkerCategory> =
+        mapNotNull { name ->
+            try {
+                SahhaBiomarkerCategory.valueOf(name.uppercase())
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Unknown biomarker category skipped: $name")
+                null
+            }
+        }.toSet()
+
+    private fun List<String>.toSahhaBiomarkerTypes(): Set<SahhaBiomarkerType> =
+        mapNotNull { name ->
+            try {
+                SahhaBiomarkerType.valueOf(name.uppercase())
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Unknown biomarker type skipped: $name")
+                null
+            }
+        }.toSet()
+
     private fun getSensorStatus(@NonNull call: MethodCall, @NonNull result: Result) {
         val sensors: List<String>? = call.argument<List<String>>("sensors")
         if (sensors == null) {
@@ -534,8 +555,8 @@ class SahhaFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
 
         if (startDateTime != null && endDateTime != null && categories != null && types != null) {
-            val biomarkerCategories = categories.map { SahhaBiomarkerCategory.valueOf(it.uppercase()) }.toSet()
-            val biomarkerTypes = types.map { SahhaBiomarkerType.valueOf(it.uppercase()) }.toSet()
+            val biomarkerCategories = categories.toSahhaBiomarkerCategories()
+            val biomarkerTypes = types.toSahhaBiomarkerTypes()
             Sahha.getBiomarkers(
                 biomarkerCategories,
                 biomarkerTypes,

--- a/android/src/main/kotlin/com/sahha/flutter/SahhaFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/sahha/flutter/SahhaFlutterPlugin.kt
@@ -383,20 +383,11 @@ class SahhaFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             return
         }
 
-        val sensorsList = sensors.toSahhaSensors()
-
-        Sahha.enableSensors(sensorsList) { error, _ ->
+        Sahha.enableSensors(sensors.toSahhaSensors()) { error, sensorStatus ->
             if (error != null) {
                 result.error("Sahha Error", error, null)
-                return@enableSensors
-            }
-            // enableSensors only returns a Boolean; query status for iOS parity.
-            Sahha.getSensorStatus(sensorsList) { statusError, sensorStatus ->
-                if (statusError != null) {
-                    result.error("Sahha Error", statusError, null)
-                } else {
-                    result.success(sensorStatus.name.lowercase())
-                }
+            } else {
+                result.success(sensorStatus.name.lowercase())
             }
         }
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Sahha (1.3.9)
-  - sahha_flutter (1.3.9):
+  - Sahha (1.4.0-beta.1)
+  - sahha_flutter (1.4.0-beta.1):
     - Flutter
-    - Sahha (= 1.3.9)
+    - Sahha (= 1.4.0-beta.1)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  Sahha: 80053864fedde618e438149b9bacd77741887052
-  sahha_flutter: 790a822a8448e12032c5369837e4ca6a77b1de92
+  Sahha: 62e9ceca5431682ddfc55fd5768ebf8c63e84e3f
+  sahha_flutter: 95bbf357e431eecc164d09d6a61f7e1fdcc7bb52
 
 PODFILE CHECKSUM: 3e9409b67ba5801961716bfaf81c42bfee93d9a9
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* sahha_flutter */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = sahha_flutter; path = ../../ios/sahha_flutter; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7D0D5EC5AA4A75740EA02248 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
@@ -67,6 +69,8 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* sahha_flutter */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
@@ -498,7 +502,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = XT5Y8DJ5XQ;
+				DEVELOPMENT_TEAM = DFT926V374;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;

--- a/example/lib/Views/AuthenticationView.dart
+++ b/example/lib/Views/AuthenticationView.dart
@@ -1,183 +1,546 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:sahha_flutter/sahha_flutter.dart';
+import 'package:sahha_flutter_example/widgets/response_sheet.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// Exercises the authentication surface of the plugin: `authenticate`,
+/// `authenticateToken`, `deauthenticate`, `isAuthenticated` and
+/// `getProfileToken`.
 class AuthenticationView extends StatefulWidget {
-  const AuthenticationView({Key? key}) : super(key: key);
+  const AuthenticationView({super.key});
 
   @override
-  AuthenticationState createState() => AuthenticationState();
+  State<AuthenticationView> createState() => AuthenticationState();
 }
 
 class AuthenticationState extends State<AuthenticationView> {
-  TextEditingController appIdController = TextEditingController();
-  TextEditingController appSecretController = TextEditingController();
-  TextEditingController externalIdController = TextEditingController();
+  final TextEditingController appIdController = TextEditingController();
+  final TextEditingController appSecretController = TextEditingController();
+  final TextEditingController externalIdController = TextEditingController();
+  final TextEditingController profileTokenController = TextEditingController();
+  final TextEditingController refreshTokenController = TextEditingController();
+
   String appId = '';
   String appSecret = '';
   String externalId = '';
+
+  bool _obscureAppSecret = true;
+  bool _isAuthenticating = false;
+  bool _isDeauthenticating = false;
+  bool _isTokenAuthenticating = false;
+
+  bool _statusLoading = true;
+  bool? _isAuthenticated;
+  String? _profileToken;
+
+  bool get _isBusy =>
+      _isAuthenticating || _isDeauthenticating || _isTokenAuthenticating;
 
   @override
   void initState() {
     super.initState();
 
     getPrefs();
+    refreshStatus();
   }
 
-  void getPrefs() async {
+  @override
+  void dispose() {
+    appIdController.dispose();
+    appSecretController.dispose();
+    externalIdController.dispose();
+    profileTokenController.dispose();
+    refreshTokenController.dispose();
+    super.dispose();
+  }
+
+  // The 'appId' / 'appSecret' / 'externalId' keys are intentionally not
+  // namespaced so existing installs of the harness keep their credentials.
+  Future<void> getPrefs() async {
     final prefs = await SharedPreferences.getInstance();
+
+    final storedAppId = prefs.getString('appId') ?? '';
+    final storedAppSecret = prefs.getString('appSecret') ?? '';
+    final storedExternalId = prefs.getString('externalId') ?? '';
+
+    if (!mounted) return;
     setState(() {
-      appId = (prefs.getString('appId') ?? '');
+      appId = storedAppId;
       appIdController.text = appId;
-      appSecret = (prefs.getString('appSecret') ?? '');
+      appSecret = storedAppSecret;
       appSecretController.text = appSecret;
-      externalId = (prefs.getString('externalId') ?? '');
+      externalId = storedExternalId;
       externalIdController.text = externalId;
     });
-
-    SahhaFlutter.isAuthenticated().then((success) {
-      showAlertDialog(context, 'AUTHENTICATED', success.toString());
-    }).catchError((error, stackTrace) => {debugPrint(error.toString())});
   }
 
-  void setPrefs() async {
+  Future<void> setPrefs() async {
     final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('appId', appId);
+    await prefs.setString('appSecret', appSecret);
+    await prefs.setString('externalId', externalId);
+  }
+
+  /// Re-reads `isAuthenticated` and `getProfileToken` for the status card.
+  Future<void> refreshStatus() async {
+    if (mounted) setState(() => _statusLoading = true);
+
+    bool? authenticated;
+    String? profileToken;
+
+    try {
+      authenticated = await SahhaFlutter.isAuthenticated();
+      debugPrint('Is Authenticated Result: $authenticated');
+    } catch (error) {
+      debugPrint('Is Authenticated Error: $error');
+    }
+
+    try {
+      profileToken = await SahhaFlutter.getProfileToken();
+      debugPrint('Get Profile Token Result: $profileToken');
+    } catch (error) {
+      debugPrint('Get Profile Token Error: $error');
+    }
+
+    if (!mounted) return;
     setState(() {
-      prefs.setString('appId', appId);
-      prefs.setString('appSecret', appSecret);
-      prefs.setString('externalId', externalId);
+      _isAuthenticated = authenticated;
+      _profileToken = profileToken;
+      _statusLoading = false;
     });
   }
 
-  onTapSave(BuildContext context) {
+  Future<void> onTapAuthenticate() async {
     if (appId.isEmpty) {
-      showAlertDialog(context, 'MISSING INFO', "You need to input an APP ID");
-    } else if (appSecret.isEmpty) {
-      showAlertDialog(
-          context, 'MISSING INFO', "You need to input an APP SECRET");
-    } else if (externalId.isEmpty) {
-      showAlertDialog(
-          context, 'MISSING INFO', "You need to input an EXTERNAL ID");
-    } else {
-      SahhaFlutter.authenticate(
-              appId: appId, appSecret: appSecret, externalId: externalId)
-          .then((success) {
-        showAlertDialog(context, 'AUTHENTICATED', success.toString());
-        setPrefs();
-      }).catchError((error, stackTrace) => {debugPrint(error.toString())});
+      return _showMissingInfo('You need to input an APP ID');
     }
+    if (appSecret.isEmpty) {
+      return _showMissingInfo('You need to input an APP SECRET');
+    }
+    if (externalId.isEmpty) {
+      return _showMissingInfo('You need to input an EXTERNAL ID');
+    }
+
+    setState(() => _isAuthenticating = true);
+
+    bool? success;
+    Object? failure;
+    try {
+      success = await SahhaFlutter.authenticate(
+        appId: appId,
+        appSecret: appSecret,
+        externalId: externalId,
+      );
+      debugPrint('Authenticate Result: $success');
+      await setPrefs();
+    } catch (error) {
+      failure = error;
+      debugPrint('Authenticate Error: $error');
+    }
+
+    if (!mounted) return;
+    setState(() => _isAuthenticating = false);
+    await refreshStatus();
+
+    if (!mounted) return;
+    await showResponseSheet(
+      context,
+      title: failure == null ? 'Authenticated' : 'Authentication failed',
+      subtitle: 'SahhaFlutter.authenticate',
+      body: (failure ?? success).toString(),
+      isError: failure != null,
+    );
   }
 
-  showAlertDialog(BuildContext context, String title, String message) {
-    AlertDialog alert = AlertDialog(
-      title: Text(title),
-      content: Text(message),
-      actions: <Widget>[
-        TextButton(
-          child: const Text('OK'),
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-        ),
-      ],
+  Future<void> onTapAuthenticateToken() async {
+    final profileToken = profileTokenController.text.trim();
+    final refreshToken = refreshTokenController.text.trim();
+
+    if (profileToken.isEmpty) {
+      return _showMissingInfo('You need to input a PROFILE TOKEN');
+    }
+    if (refreshToken.isEmpty) {
+      return _showMissingInfo('You need to input a REFRESH TOKEN');
+    }
+
+    setState(() => _isTokenAuthenticating = true);
+
+    bool? success;
+    Object? failure;
+    try {
+      success = await SahhaFlutter.authenticateToken(
+        profileToken: profileToken,
+        refreshToken: refreshToken,
+      );
+      debugPrint('Authenticate Token Result: $success');
+    } catch (error) {
+      failure = error;
+      debugPrint('Authenticate Token Error: $error');
+    }
+
+    if (!mounted) return;
+    setState(() => _isTokenAuthenticating = false);
+    await refreshStatus();
+
+    if (!mounted) return;
+    await showResponseSheet(
+      context,
+      title: failure == null ? 'Authenticated' : 'Token authentication failed',
+      subtitle: 'SahhaFlutter.authenticateToken',
+      body: (failure ?? success).toString(),
+      isError: failure != null,
+    );
+  }
+
+  Future<void> onTapDeauthenticate() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        final scheme = Theme.of(dialogContext).colorScheme;
+        return AlertDialog(
+          title: const Text('Deauthenticate?'),
+          content: const Text(
+            'This signs the current profile out of the SDK on this device. '
+            'The external ID will be cleared.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              style: TextButton.styleFrom(foregroundColor: scheme.error),
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Deauthenticate'),
+            ),
+          ],
+        );
+      },
     );
 
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return alert;
-      },
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _isDeauthenticating = true);
+
+    bool? success;
+    Object? failure;
+    try {
+      success = await SahhaFlutter.deauthenticate();
+      debugPrint('Deauthenticate Result: $success');
+    } catch (error) {
+      failure = error;
+      debugPrint('Deauthenticate Error: $error');
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _isDeauthenticating = false;
+      if (failure == null) {
+        externalId = '';
+        externalIdController.text = '';
+      }
+    });
+    if (failure == null) await setPrefs();
+    await refreshStatus();
+
+    if (!mounted) return;
+    await showResponseSheet(
+      context,
+      title: failure == null ? 'Deauthenticated' : 'Deauthentication failed',
+      subtitle: 'SahhaFlutter.deauthenticate',
+      body: (failure ?? success).toString(),
+      isError: failure != null,
+    );
+  }
+
+  Future<void> _showMissingInfo(String message) {
+    return showResponseSheet(
+      context,
+      title: 'Missing info',
+      body: message,
+      isError: true,
+    );
+  }
+
+  void _copyProfileToken() {
+    final token = _profileToken;
+    if (token == null || token.isEmpty) return;
+    Clipboard.setData(ClipboardData(text: token));
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Profile token copied to clipboard')),
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Authentication'),
+        actions: [
+          IconButton(
+            tooltip: 'Refresh status',
+            icon: const Icon(Icons.refresh),
+            onPressed: _statusLoading ? null : refreshStatus,
+          ),
+        ],
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(40),
-        child: Center(
-          child: Column(
-            children: <Widget>[
-              const Spacer(),
-              const Icon(
-                Icons.lock,
-                size: 64,
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+        children: [
+          _buildStatusCard(theme),
+          const _SectionLabel('App credentials'),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  TextField(
+                    controller: appIdController,
+                    autocorrect: false,
+                    enableSuggestions: false,
+                    decoration: const InputDecoration(labelText: 'APP ID'),
+                    onChanged: (text) => setState(() => appId = text),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: appSecretController,
+                    autocorrect: false,
+                    enableSuggestions: false,
+                    obscureText: _obscureAppSecret,
+                    decoration: InputDecoration(
+                      labelText: 'APP SECRET',
+                      suffixIcon: IconButton(
+                        tooltip: _obscureAppSecret
+                            ? 'Show app secret'
+                            : 'Hide app secret',
+                        icon: Icon(
+                          _obscureAppSecret
+                              ? Icons.visibility_outlined
+                              : Icons.visibility_off_outlined,
+                          size: 20,
+                        ),
+                        onPressed: () => setState(
+                          () => _obscureAppSecret = !_obscureAppSecret,
+                        ),
+                      ),
+                    ),
+                    onChanged: (text) => setState(() => appSecret = text),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: externalIdController,
+                    autocorrect: false,
+                    enableSuggestions: false,
+                    decoration: const InputDecoration(labelText: 'EXTERNAL ID'),
+                    onChanged: (text) => setState(() => externalId = text),
+                  ),
+                ],
               ),
-              const SizedBox(height: 20),
+            ),
+          ),
+          const SizedBox(height: 20),
+          FilledButton(
+            onPressed: _isBusy ? null : onTapAuthenticate,
+            child: _busyLabel(
+              context,
+              busy: _isAuthenticating,
+              label: 'AUTHENTICATE',
+            ),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton(
+            onPressed: _isBusy ? null : onTapDeauthenticate,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: theme.colorScheme.error,
+              side: BorderSide(color: theme.colorScheme.error),
+            ),
+            child: _busyLabel(
+              context,
+              busy: _isDeauthenticating,
+              label: 'DEAUTHENTICATE',
+            ),
+          ),
+          const _SectionLabel('Advanced'),
+          ExpansionTile(
+            leading: const Icon(Icons.vpn_key_outlined),
+            title: const Text('Authenticate with tokens'),
+            subtitle: const Text('SahhaFlutter.authenticateToken'),
+            // Children default to centre alignment, which would shrink the
+            // fields and button to their intrinsic width.
+            expandedCrossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
               TextField(
-                controller: appIdController,
+                controller: profileTokenController,
                 autocorrect: false,
                 enableSuggestions: false,
-                decoration: const InputDecoration(labelText: "APP ID"),
-                onChanged: (text) {
-                  setState(() {
-                    appId = appIdController.text;
-                  });
-                },
+                maxLines: 2,
+                minLines: 1,
+                decoration: const InputDecoration(labelText: 'PROFILE TOKEN'),
               ),
+              const SizedBox(height: 12),
               TextField(
-                controller: appSecretController,
+                controller: refreshTokenController,
                 autocorrect: false,
                 enableSuggestions: false,
-                decoration: const InputDecoration(labelText: "APP SECRET"),
-                onChanged: (text) {
-                  setState(() {
-                    appSecret = appSecretController.text;
-                  });
-                },
+                maxLines: 2,
+                minLines: 1,
+                decoration: const InputDecoration(labelText: 'REFRESH TOKEN'),
               ),
-              TextField(
-                controller: externalIdController,
-                autocorrect: false,
-                enableSuggestions: false,
-                decoration: const InputDecoration(labelText: "EXTERNAL ID"),
-                onChanged: (text) {
-                  setState(() {
-                    externalId = externalIdController.text;
-                  });
-                },
-              ),
-              const SizedBox(height: 20),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size.fromHeight(40),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                  textStyle: const TextStyle(fontSize: 16),
+              const SizedBox(height: 16),
+              FilledButton.tonal(
+                onPressed: _isBusy ? null : onTapAuthenticateToken,
+                child: _busyLabel(
+                  context,
+                  busy: _isTokenAuthenticating,
+                  label: 'AUTHENTICATE WITH TOKENS',
                 ),
-                onPressed: () {
-                  onTapSave(context);
-                },
-                child: const Text('AUTHENTICATE'),
-              ),
-              const SizedBox(height: 20),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size.fromHeight(40),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                  textStyle: const TextStyle(fontSize: 16),
-                ),
-                onPressed: () {
-                  SahhaFlutter.deauthenticate().then((success) {
-                    showAlertDialog(
-                        context, 'DEAUTHENTICATED', success.toString());
-                    setState(() {
-                      externalIdController.text = '';
-                      externalId = '';
-                    });
-                    setPrefs();
-                  }).catchError(
-                      (error, stackTrace) => {debugPrint(error.toString())});
-                },
-                child: const Text('DEAUTHENTICATE'),
               ),
             ],
           ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatusCard(ThemeData theme) {
+    final bool authenticated = _isAuthenticated ?? false;
+    final bool unknown = _isAuthenticated == null;
+    final Color accent = unknown
+        ? Colors.grey.shade600
+        : authenticated
+        ? Colors.green.shade600
+        : Colors.orange.shade800;
+    final String label = unknown
+        ? 'Unknown'
+        : authenticated
+        ? 'Authenticated'
+        : 'Not authenticated';
+    final String? token = _profileToken;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  'Status',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const Spacer(),
+                if (_statusLoading)
+                  const SizedBox(
+                    height: 16,
+                    width: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                else
+                  _StatusChip(label: label, color: accent),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Profile token',
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    token == null || token.isEmpty
+                        ? 'None'
+                        : _truncateToken(token),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: monoStyle(context, fontSize: 13),
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Copy profile token',
+                  icon: const Icon(Icons.copy_outlined, size: 18),
+                  onPressed: token == null || token.isEmpty
+                      ? null
+                      : _copyProfileToken,
+                ),
+              ],
+            ),
+          ],
         ),
+      ),
+    );
+  }
+
+  static String _truncateToken(String token) {
+    if (token.length <= 26) return token;
+    return '${token.substring(0, 14)}…${token.substring(token.length - 8)}';
+  }
+
+  static Widget _busyLabel(
+    BuildContext context, {
+    required bool busy,
+    required String label,
+  }) {
+    if (!busy) return Text(label);
+    return SizedBox(
+      height: 20,
+      width: 20,
+      child: CircularProgressIndicator(
+        strokeWidth: 2,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 24, 4, 8),
+      child: Text(
+        text,
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: theme.colorScheme.primary,
+          letterSpacing: 0.8,
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(color: color),
       ),
     );
   }

--- a/example/lib/Views/BiomarkersView.dart
+++ b/example/lib/Views/BiomarkersView.dart
@@ -1,135 +1,685 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:sahha_flutter/sahha_flutter.dart';
+import 'package:sahha_flutter_example/widgets/date_range_selector.dart';
+import 'package:sahha_flutter_example/widgets/multi_select_sheet.dart';
+import 'package:sahha_flutter_example/widgets/response_sheet.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+const _categoriesPrefsKey = 'biomarkers.categories';
+const _typesPrefsKey = 'biomarkers.types';
+
+/// Test harness for [SahhaFlutter.getBiomarkers]: pick categories, types and a
+/// date range, then inspect the parsed response inline.
 class BiomarkersView extends StatefulWidget {
-  const BiomarkersView({Key? key}) : super(key: key);
+  const BiomarkersView({super.key});
 
   @override
-  BiomarkersState createState() => BiomarkersState();
+  State<BiomarkersView> createState() => BiomarkersState();
 }
 
 class BiomarkersState extends State<BiomarkersView> {
+  static final DateFormat _dateTimeFormat = DateFormat('d MMM, HH:mm');
+
+  final Set<SahhaBiomarkerCategory> _categories = {
+    ...SahhaBiomarkerCategory.values,
+  };
+  final Set<SahhaBiomarkerType> _types = {...SahhaBiomarkerType.values};
+
+  DateTime _start = DateTime.now().subtract(const Duration(days: 7));
+  DateTime _end = DateTime.now();
+
+  bool _isLoading = false;
+
+  /// Raw response of the last successful call, `null` before the first one.
+  String? _rawResponse;
+  List<_BiomarkerEntry> _entries = const [];
+  DateTime? _queriedStart;
+  DateTime? _queriedEnd;
+
   @override
   void initState() {
     super.initState();
 
-    getPrefs();
+    _restoreSelections();
   }
 
-  void getPrefs() async {
+  bool get _hasSelection => _categories.isNotEmpty && _types.isNotEmpty;
+
+  /// Selections in enum order so the request is stable regardless of the order
+  /// the user tapped things in.
+  List<SahhaBiomarkerCategory> get _selectedCategories => [
+    for (final category in SahhaBiomarkerCategory.values)
+      if (_categories.contains(category)) category,
+  ];
+
+  List<SahhaBiomarkerType> get _selectedTypes => [
+    for (final type in SahhaBiomarkerType.values)
+      if (_types.contains(type)) type,
+  ];
+
+  Future<void> _restoreSelections() async {
     final prefs = await SharedPreferences.getInstance();
-    setState(() {});
+    final categories = _restore(
+      prefs.getStringList(_categoriesPrefsKey),
+      SahhaBiomarkerCategory.values,
+    );
+    final types = _restore(
+      prefs.getStringList(_typesPrefsKey),
+      SahhaBiomarkerType.values,
+    );
+    if (!mounted) return;
+    setState(() {
+      if (categories != null) {
+        _categories
+          ..clear()
+          ..addAll(categories);
+      }
+      if (types != null) {
+        _types
+          ..clear()
+          ..addAll(types);
+      }
+    });
   }
 
-  void setPrefs() async {
+  /// Maps stored enum names back to values, silently dropping names that no
+  /// longer exist. Returns `null` (keep the defaults) when nothing was stored
+  /// or when every stored name is unknown.
+  Set<T>? _restore<T extends Enum>(List<String>? stored, List<T> values) {
+    if (stored == null) return null;
+    final byName = {for (final value in values) value.name: value};
+    final restored = <T>{
+      for (final name in stored)
+        if (byName[name] case final value?) value,
+    };
+    if (restored.isEmpty && stored.isNotEmpty) return null;
+    return restored;
+  }
+
+  Future<void> _persistSelections() async {
     final prefs = await SharedPreferences.getInstance();
-    setState(() {});
+    await prefs.setStringList(_categoriesPrefsKey, [
+      for (final category in _selectedCategories) category.name,
+    ]);
+    await prefs.setStringList(_typesPrefsKey, [
+      for (final type in _selectedTypes) type.name,
+    ]);
   }
 
-  onTapGetBiomarkers(BuildContext context, bool isDaily) {
-    if (isDaily) {
-      SahhaFlutter.getBiomarkers(
-              categories: SahhaBiomarkerCategory.values,
-              types: SahhaBiomarkerType.values,
-              startDateTime: DateTime.now(),
-              endDateTime: DateTime.now())
-          .then((value) {
-        final data = jsonDecode(value);
-        debugPrint(data.toString());
-        showAlertDialog(context, value);
-      }).catchError((error, stackTrace) => {debugPrint(error.toString())});
-    } else {
-      var week = DateTime.now().subtract(const Duration(days: 7));
-      SahhaFlutter.getBiomarkers(
-              categories: SahhaBiomarkerCategory.values,
-              types: SahhaBiomarkerType.values,
-              startDateTime: week,
-              endDateTime: DateTime.now())
-          .then((value) {
-        final data = jsonDecode(value);
-        debugPrint(data.toString());
-        showAlertDialog(context, value);
-      }).catchError((error, stackTrace) => {debugPrint(error.toString())});
+  void _toggleCategory(SahhaBiomarkerCategory category, bool selected) {
+    setState(() {
+      if (selected) {
+        _categories.add(category);
+      } else {
+        _categories.remove(category);
+      }
+    });
+    _persistSelections();
+  }
+
+  Future<void> _pickTypes() async {
+    final selection = await showMultiSelectSheet<SahhaBiomarkerType>(
+      context: context,
+      title: 'Biomarker types',
+      options: _typesGroupedInEnumOrder(),
+      initialSelection: _types,
+      labelOf: (type) => type.name,
+      groupOf: _biomarkerGroupOf,
+    );
+    if (selection == null || !mounted) return;
+    setState(() {
+      _types
+        ..clear()
+        ..addAll(selection);
+    });
+    await _persistSelections();
+  }
+
+  Future<void> _getBiomarkers() async {
+    if (!_hasSelection || _isLoading) return;
+
+    final start = _start;
+    final end = _end;
+    setState(() => _isLoading = true);
+
+    try {
+      final raw = await SahhaFlutter.getBiomarkers(
+        categories: _selectedCategories,
+        types: _selectedTypes,
+        startDateTime: start,
+        endDateTime: end,
+      );
+      debugPrint('GET BIOMARKERS: $raw');
+      final entries = _parseEntries(raw);
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _rawResponse = raw;
+        _entries = entries;
+        _queriedStart = start;
+        _queriedEnd = end;
+      });
+    } catch (error) {
+      debugPrint('GET BIOMARKERS error: $error');
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _rawResponse = null;
+        _entries = const [];
+        _queriedStart = null;
+        _queriedEnd = null;
+      });
+      await showResponseSheet(
+        context,
+        title: 'GET BIOMARKERS',
+        body: error.toString(),
+        subtitle: 'Request failed — authenticate the profile and try again',
+        isError: true,
+      );
     }
   }
 
-  showAlertDialog(BuildContext context, String value) {
-    AlertDialog alert = AlertDialog(
-      title: const Text('BIOMARKERS'),
-      content: SingleChildScrollView(
-        child: Text(value),
-      ),
-      actions: <Widget>[
-        TextButton(
-          child: const Text('OK'),
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-        ),
-      ],
-    );
-
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return alert;
-      },
-    );
+  List<_BiomarkerEntry> _parseEntries(String raw) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } catch (error) {
+      debugPrint('GET BIOMARKERS: response was not JSON ($error)');
+      return const [];
+    }
+    if (decoded is! List) return const [];
+    return [
+      for (final item in decoded)
+        if (item is Map) _BiomarkerEntry(item),
+    ];
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final totalTypes = SahhaBiomarkerType.values.length;
+    final typesSummary = _types.length == totalTypes
+        ? 'All types ($totalTypes)'
+        : '${_types.length} of $totalTypes selected';
+
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Biomarkers'),
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(40),
-          child: Center(
-            child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  const Spacer(),
-                  const Icon(
-                    Icons.insert_chart,
-                    size: 64,
-                  ),
-                  const SizedBox(height: 20),
-                  const Text('A new score will be available every 6 hours',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(fontSize: 18)),
-                  const SizedBox(height: 20),
-                  const SizedBox(height: 20),
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      minimumSize: const Size.fromHeight(40),
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 40, vertical: 20),
-                      textStyle: const TextStyle(fontSize: 16),
-                    ),
-                    onPressed: () {
-                      onTapGetBiomarkers(context, false);
-                    },
-                    child: const Text('GET BIOMARKERS PREVIOUS WEEK'),
-                  ),
-                  const SizedBox(height: 20),
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      minimumSize: const Size.fromHeight(40),
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 40, vertical: 20),
-                      textStyle: const TextStyle(fontSize: 16),
-                    ),
-                    onPressed: () {
-                      onTapGetBiomarkers(context, true);
-                    },
-                    child: const Text('GET BIOMARKERS TODAY'),
-                  ),
-                ]),
+      appBar: AppBar(title: const Text('Biomarkers')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 20, 20, 40),
+        children: [
+          _sectionHeader(theme, 'Categories'),
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            children: [
+              for (final category in SahhaBiomarkerCategory.values)
+                FilterChip(
+                  label: Text(_prettyLabel(category.name)),
+                  selected: _categories.contains(category),
+                  onSelected: (selected) => _toggleCategory(category, selected),
+                ),
+            ],
           ),
-        ));
+          const SizedBox(height: 24),
+          _sectionHeader(theme, 'Types'),
+          InkWell(
+            onTap: _pickTypes,
+            borderRadius: BorderRadius.circular(8),
+            child: InputDecorator(
+              decoration: const InputDecoration(
+                labelText: 'Biomarker types',
+                border: OutlineInputBorder(),
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
+                suffixIcon: Icon(Icons.tune, size: 18),
+              ),
+              child: Text(typesSummary, style: theme.textTheme.bodyMedium),
+            ),
+          ),
+          const SizedBox(height: 24),
+          _sectionHeader(theme, 'Date range'),
+          DateRangeSelector(
+            start: _start,
+            end: _end,
+            onChanged: (start, end) => setState(() {
+              _start = start;
+              _end = end;
+            }),
+          ),
+          const SizedBox(height: 24),
+          if (!_hasSelection)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: _InlineHint(
+                message: _categories.isEmpty
+                    ? 'Select at least one category to run the request.'
+                    : 'Select at least one biomarker type to run the request.',
+              ),
+            ),
+          FilledButton(
+            onPressed: _hasSelection && !_isLoading ? _getBiomarkers : null,
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48),
+            ),
+            child: _isLoading
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('GET BIOMARKERS'),
+          ),
+          ..._buildResults(theme),
+        ],
+      ),
+    );
   }
+
+  Widget _sectionHeader(ThemeData theme, String label) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(
+        label,
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: theme.colorScheme.primary,
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildResults(ThemeData theme) {
+    final raw = _rawResponse;
+    if (raw == null) return const [];
+
+    final start = _queriedStart;
+    final end = _queriedEnd;
+    final range = start != null && end != null
+        ? '${_dateTimeFormat.format(start)} – ${_dateTimeFormat.format(end)}'
+        : null;
+
+    // Insertion ordered, so types appear in the order the API returned them.
+    final grouped = <String, List<_BiomarkerEntry>>{};
+    for (final entry in _entries) {
+      grouped.putIfAbsent(entry.type ?? 'Unknown type', () => []).add(entry);
+    }
+
+    return [
+      const SizedBox(height: 28),
+      const Divider(height: 1),
+      Padding(
+        padding: const EdgeInsets.only(top: 12, bottom: 8),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _entries.length == 1
+                        ? '1 result'
+                        : '${_entries.length} results',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  if (range != null)
+                    Text(
+                      range,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            TextButton(
+              onPressed: () => showResponseSheet(
+                context,
+                title: 'GET BIOMARKERS',
+                body: tryPrettyJson(raw),
+                subtitle: '${_entries.length} results',
+              ),
+              child: const Text('Raw JSON'),
+            ),
+          ],
+        ),
+      ),
+      if (_entries.isEmpty)
+        const _EmptyResults()
+      else
+        for (final group in grouped.entries)
+          Card(
+            margin: const EdgeInsets.only(bottom: 8),
+            clipBehavior: Clip.antiAlias,
+            child: ExpansionTile(
+              // The card already draws the border and padding, so the tile
+              // stays flush with it whatever the app theme sets.
+              shape: const Border(),
+              collapsedShape: const Border(),
+              childrenPadding: EdgeInsets.zero,
+              expandedCrossAxisAlignment: CrossAxisAlignment.start,
+              initiallyExpanded: grouped.length == 1,
+              title: Text(
+                _prettyLabel(group.key),
+                style: theme.textTheme.titleSmall,
+              ),
+              subtitle: Text(
+                group.value.length == 1
+                    ? '1 entry'
+                    : '${group.value.length} entries',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              children: [
+                for (final entry in group.value)
+                  _BiomarkerRow(entry: entry, dateTimeFormat: _dateTimeFormat),
+              ],
+            ),
+          ),
+    ];
+  }
+}
+
+class _BiomarkerRow extends StatelessWidget {
+  const _BiomarkerRow({required this.entry, required this.dateTimeFormat});
+
+  final _BiomarkerEntry entry;
+  final DateFormat dateTimeFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final unit = entry.unit;
+    final value = entry.value ?? '—';
+    final chips = <String>[
+      if (entry.periodicity case final periodicity?) periodicity,
+      if (entry.aggregation case final aggregation?) aggregation,
+      if (entry.category case final category?) category,
+    ];
+    final period = _period(
+      dateTimeFormat,
+      entry.startDateTime,
+      entry.endDateTime,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            unit == null || unit.isEmpty ? value : '$value $unit',
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          if (chips.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: [for (final chip in chips) _MiniChip(label: chip)],
+              ),
+            ),
+          if (period != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Text(
+                period,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  static String? _period(DateFormat format, Object? start, Object? end) {
+    final startLabel = _formatDateTime(format, start);
+    final endLabel = _formatDateTime(format, end);
+    if (startLabel == null && endLabel == null) return null;
+    if (startLabel == null) return 'until $endLabel';
+    if (endLabel == null) return 'from $startLabel';
+    return '$startLabel – $endLabel';
+  }
+}
+
+class _MiniChip extends StatelessWidget {
+  const _MiniChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineHint extends StatelessWidget {
+  const _InlineHint({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          Icons.info_outline,
+          size: 18,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            message,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyResults extends StatelessWidget {
+  const _EmptyResults();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            Icon(
+              Icons.inbox_outlined,
+              size: 40,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'No biomarkers for this range',
+              style: theme.textTheme.titleSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Sensor data can take a while to process after it is collected. '
+              'Check that the profile is authenticated, that the sensors for '
+              'these types are enabled, and try a wider date range.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// One item of the `getBiomarkers` response.
+///
+/// Keys are normalised (lower cased, underscores stripped) so the same getter
+/// works whether the platform returns `startDateTime` or `start_date_time`, and
+/// every getter tolerates a missing or unexpectedly typed field.
+class _BiomarkerEntry {
+  _BiomarkerEntry(Map<Object?, Object?> json)
+    : _fields = {
+        for (final entry in json.entries) _normaliseKey(entry.key): entry.value,
+      };
+
+  final Map<String, Object?> _fields;
+
+  static String _normaliseKey(Object? key) =>
+      key.toString().toLowerCase().replaceAll('_', '');
+
+  Object? _raw(String key) => _fields[_normaliseKey(key)];
+
+  String? _string(String key) {
+    final raw = _raw(key);
+    if (raw == null) return null;
+    final value = raw.toString().trim();
+    return value.isEmpty ? null : value;
+  }
+
+  String? get category => _string('category');
+
+  String? get type =>
+      _string('type') ?? _string('biomarkerType') ?? _string('name');
+
+  String? get value {
+    final raw = _raw('value');
+    if (raw == null) return null;
+    if (raw is num) return _formatNumber(raw);
+    final value = raw.toString().trim();
+    return value.isEmpty ? null : value;
+  }
+
+  String? get unit => _string('unit');
+
+  String? get periodicity => _string('periodicity');
+
+  String? get aggregation => _string('aggregation');
+
+  Object? get startDateTime => _raw('startDateTime') ?? _raw('startDate');
+
+  Object? get endDateTime => _raw('endDateTime') ?? _raw('endDate');
+}
+
+/// Buckets [SahhaBiomarkerType] into readable groups for the picker. Every
+/// value of the enum currently maps to one of the five named groups; `Other`
+/// is a safety net for values added to the plugin later.
+String _biomarkerGroupOf(SahhaBiomarkerType type) {
+  final name = type.name;
+  bool startsWithAny(List<String> prefixes) =>
+      prefixes.any((prefix) => name.startsWith(prefix));
+
+  // Order matters: the vitals check runs before the body check so that
+  // `body_temperature_basal` stays with the other temperatures, and the sleep
+  // check only matches the `sleep_` prefix so that `heart_rate_sleep` and
+  // friends stay in vitals.
+  if (name.startsWith('sleep_')) return 'Sleep';
+  if (startsWithAny(const [
+    'heart_',
+    'respiratory',
+    'oxygen',
+    'blood_',
+    'vo2',
+    'body_temperature',
+    'skin_temperature',
+  ])) {
+    return 'Vitals';
+  }
+  if (startsWithAny(const [
+    'steps',
+    'floors_climbed',
+    'active_',
+    'activity_',
+    'total_energy_burned',
+  ])) {
+    return 'Activity';
+  }
+  if (startsWithAny(const [
+    'height',
+    'weight',
+    'body_',
+    'fat_mass',
+    'lean_mass',
+    'waist_circumference',
+    'resting_energy_burned',
+  ])) {
+    return 'Body';
+  }
+  if (startsWithAny(const ['age', 'biological_sex', 'date_of_birth'])) {
+    return 'Demographic';
+  }
+  return 'Other';
+}
+
+/// Types in enum order, sorted so each group is contiguous even if a future
+/// enum addition breaks the current ordering.
+List<SahhaBiomarkerType> _typesGroupedInEnumOrder() {
+  final byGroup = <String, List<SahhaBiomarkerType>>{};
+  for (final type in SahhaBiomarkerType.values) {
+    byGroup.putIfAbsent(_biomarkerGroupOf(type), () => []).add(type);
+  }
+  return [for (final group in byGroup.values) ...group];
+}
+
+/// `sleep_rem_duration` -> `Sleep rem duration`.
+String _prettyLabel(String name) {
+  final words = name.replaceAll('_', ' ').trim();
+  if (words.isEmpty) return name;
+  return words[0].toUpperCase() + words.substring(1);
+}
+
+String _formatNumber(num value) {
+  if (value.isNaN || value.isInfinite) return value.toString();
+  if (value is int || value == value.roundToDouble()) {
+    return value.toInt().toString();
+  }
+  return value.toStringAsFixed(2);
+}
+
+/// Formats an ISO 8601 string or epoch milliseconds, falling back to the raw
+/// value when it is neither.
+String? _formatDateTime(DateFormat format, Object? raw) {
+  if (raw == null) return null;
+  if (raw is num) {
+    return format.format(
+      DateTime.fromMillisecondsSinceEpoch(raw.toInt(), isUtc: true).toLocal(),
+    );
+  }
+  final text = raw.toString().trim();
+  if (text.isEmpty) return null;
+  final parsed = DateTime.tryParse(text);
+  return parsed == null ? text : format.format(parsed.toLocal());
 }

--- a/example/lib/Views/HomeView.dart
+++ b/example/lib/Views/HomeView.dart
@@ -1,169 +1,419 @@
 import 'package:flutter/material.dart';
 import 'package:sahha_flutter/sahha_flutter.dart';
 
-class HomeView extends StatelessWidget {
-  const HomeView({Key? key}) : super(key: key);
+/// Dashboard for the test harness: an authentication status banner plus the
+/// screens that exercise each area of the plugin API, grouped by concern.
+class HomeView extends StatefulWidget {
+  const HomeView({super.key});
+
+  @override
+  State<HomeView> createState() => HomeState();
+}
+
+class HomeState extends State<HomeView> {
+  /// Null while the first check is in flight, or after a failed check.
+  bool? _isAuthenticated;
+  String? _authError;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshAuthStatus();
+  }
+
+  Future<void> _refreshAuthStatus() async {
+    try {
+      final value = await SahhaFlutter.isAuthenticated();
+      debugPrint('isAuthenticated: $value');
+      if (!mounted) return;
+      setState(() {
+        _isAuthenticated = value;
+        _authError = null;
+      });
+    } catch (error) {
+      debugPrint('isAuthenticated error: $error');
+      if (!mounted) return;
+      setState(() {
+        _isAuthenticated = null;
+        _authError = error.toString();
+      });
+    }
+  }
+
+  /// Pushes [route] and re-checks authentication when the screen comes back,
+  /// so the banner reflects anything the pushed screen changed.
+  Future<void> _open(String route) async {
+    await Navigator.pushNamed(context, route);
+    if (!mounted) return;
+    await _refreshAuthStatus();
+  }
+
+  void _postSensorData() {
+    debugPrint('Post Sensor Data requested');
+    SahhaFlutter.postSensorData();
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Sensor data post requested')));
+  }
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Sahha Demo'),
+      appBar: AppBar(
+        title: const Text('Sahha Demo'),
+        actions: [
+          IconButton(
+            tooltip: 'Refresh status',
+            icon: const Icon(Icons.refresh),
+            onPressed: _refreshAuthStatus,
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+        children: [
+          _AuthBanner(
+            isAuthenticated: _isAuthenticated,
+            error: _authError,
+            onTap: () => _open('/authentication'),
+          ),
+          _Section(
+            title: 'Setup',
+            tiles: [
+              _NavTile(
+                icon: Icons.lock_outline,
+                iconColor: scheme.onPrimaryContainer,
+                iconBackground: scheme.primaryContainer,
+                title: 'Authentication',
+                subtitle: 'Authenticate, deauthenticate, profile tokens',
+                onTap: () => _open('/authentication'),
+              ),
+              _NavTile(
+                icon: Icons.person_outline,
+                iconColor: scheme.onPrimaryContainer,
+                iconBackground: scheme.primaryContainer,
+                title: 'Profile',
+                subtitle: 'Post and fetch demographic details',
+                onTap: () => _open('/profile'),
+              ),
+            ],
+          ),
+          _Section(
+            title: 'Sensors',
+            tiles: [
+              _NavTile(
+                icon: Icons.sensors,
+                iconColor: scheme.onSecondaryContainer,
+                iconBackground: scheme.secondaryContainer,
+                title: 'Sensor Permissions',
+                subtitle: 'Enable or check status for a chosen sensor set',
+                onTap: () => _open('/permissions'),
+              ),
+              _NavTile(
+                icon: Icons.fact_check_outlined,
+                iconColor: scheme.onSecondaryContainer,
+                iconBackground: scheme.secondaryContainer,
+                title: 'Sensor Diagnostics',
+                subtitle: 'Per-sensor status across the whole sensor list',
+                onTap: () => _open('/diagnostics'),
+              ),
+              _NavTile(
+                icon: Icons.cloud_upload_outlined,
+                iconColor: scheme.onSecondaryContainer,
+                iconBackground: scheme.secondaryContainer,
+                title: 'Post Sensor Data',
+                subtitle: 'Trigger an immediate upload of collected data',
+                trailing: const Icon(Icons.upload_outlined),
+                onTap: _postSensorData,
+              ),
+            ],
+          ),
+          _Section(
+            title: 'Data',
+            tiles: [
+              _NavTile(
+                icon: Icons.query_stats,
+                iconColor: scheme.onTertiaryContainer,
+                iconBackground: scheme.tertiaryContainer,
+                title: 'Scores',
+                subtitle: 'getScores over a score type and date range',
+                onTap: () => _open('/scores'),
+              ),
+              _NavTile(
+                icon: Icons.insert_chart_outlined,
+                iconColor: scheme.onTertiaryContainer,
+                iconBackground: scheme.tertiaryContainer,
+                title: 'Biomarkers',
+                subtitle: 'getBiomarkers by category, type and date range',
+                onTap: () => _open('/biomarkers'),
+              ),
+              _NavTile(
+                icon: Icons.pie_chart_outline,
+                iconColor: scheme.onTertiaryContainer,
+                iconBackground: scheme.tertiaryContainer,
+                title: 'Stats',
+                subtitle: 'getStats aggregates for a single sensor',
+                isDeprecated: true,
+                onTap: () => _open('/stats'),
+              ),
+              _NavTile(
+                icon: Icons.timer_outlined,
+                iconColor: scheme.onTertiaryContainer,
+                iconBackground: scheme.tertiaryContainer,
+                title: 'Samples',
+                subtitle: 'getSamples raw readings for a single sensor',
+                isDeprecated: true,
+                onTap: () => _open('/samples'),
+              ),
+            ],
+          ),
+          _Section(
+            title: 'Insights',
+            tiles: [
+              _NavTile(
+                icon: Icons.psychology_outlined,
+                iconColor: scheme.onPrimaryContainer,
+                iconBackground: scheme.primaryContainer,
+                title: 'Insights',
+                subtitle: 'Sahha web view authorised with the profile token',
+                onTap: () => _open('/web'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Authentication status card: green when authenticated, orange when not,
+/// grey while unknown. Tapping it jumps to the authentication screen.
+class _AuthBanner extends StatelessWidget {
+  const _AuthBanner({
+    required this.isAuthenticated,
+    required this.error,
+    required this.onTap,
+  });
+
+  final bool? isAuthenticated;
+  final String? error;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final bool authenticated = isAuthenticated ?? false;
+    final bool unknown = isAuthenticated == null;
+
+    final Color accent = unknown
+        ? Colors.grey.shade600
+        : authenticated
+        ? Colors.green.shade600
+        : Colors.orange.shade800;
+
+    final String title = unknown
+        ? (error == null ? 'Checking status…' : 'Status unavailable')
+        : authenticated
+        ? 'Authenticated'
+        : 'Not authenticated';
+
+    final String subtitle = unknown
+        ? (error ?? 'Reading isAuthenticated from the SDK')
+        : authenticated
+        ? 'A profile is signed in on this device'
+        : 'Tap to authenticate before fetching data';
+
+    final IconData icon = unknown
+        ? (error == null ? Icons.hourglass_empty : Icons.help_outline)
+        : authenticated
+        ? Icons.verified_user_outlined
+        : Icons.gpp_maybe_outlined;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Card(
+        color: accent.withValues(alpha: 0.10),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: BorderSide(color: accent.withValues(alpha: 0.45)),
         ),
-        body: Padding(
-          padding: const EdgeInsets.all(40),
-          child: ListView(children: <Widget>[
-            ElevatedButton.icon(
-              icon: const Icon(
-                Icons.lock,
-                size: 32,
-              ),
-              label: const Text('Authentication'),
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-                padding: const EdgeInsets.all(20),
-                textStyle: const TextStyle(fontSize: 20),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/authentication');
-              },
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Icon(icon, color: accent, size: 28),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: accent,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ],
             ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              icon: const Icon(
-                Icons.person,
-                size: 32,
-              ),
-              label: const Text('Profile'),
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-                padding: const EdgeInsets.all(20),
-                textStyle: const TextStyle(fontSize: 20),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/profile');
-              },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A labelled group of tiles rendered as one card.
+class _Section extends StatelessWidget {
+  const _Section({required this.title, required this.tiles});
+
+  final String title;
+  final List<Widget> tiles;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(4, 20, 4, 8),
+          child: Text(
+            title,
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: theme.colorScheme.primary,
+              letterSpacing: 0.8,
             ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              icon: const Icon(
-                Icons.sensors,
-                size: 32,
+          ),
+        ),
+        Card(
+          child: Column(
+            children: [
+              for (var i = 0; i < tiles.length; i++) ...[
+                if (i > 0) const Divider(height: 1, indent: 72),
+                tiles[i],
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Dashboard row: tinted icon, title, one-line description of what the
+/// destination tests, and a trailing affordance.
+class _NavTile extends StatelessWidget {
+  const _NavTile({
+    required this.icon,
+    required this.iconColor,
+    required this.iconBackground,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    this.trailing,
+    this.isDeprecated = false,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final Color iconBackground;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+  final Widget? trailing;
+  final bool isDeprecated;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ListTile(
+      onTap: onTap,
+      shape: const RoundedRectangleBorder(),
+      leading: Container(
+        width: 40,
+        height: 40,
+        decoration: BoxDecoration(
+          color: iconBackground,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Icon(icon, size: 20, color: iconColor),
+      ),
+      title: Row(
+        children: [
+          Flexible(
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
               ),
-              label: const Text('Sensor Permissions'),
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                textStyle: const TextStyle(fontSize: 20),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/permissions');
-              },
             ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              icon: const Icon(
-                Icons.query_stats,
-                size: 32,
-              ),
-              label: const Text('Scores'),
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                textStyle: const TextStyle(fontSize: 20),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/scores');
-              },
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              icon: const Icon(
-                Icons.insert_chart,
-                size: 32,
-              ),
-              label: const Text('Biomarkers'),
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                textStyle: const TextStyle(fontSize: 20),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/biomarkers');
-              },
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              icon: const Icon(
-                Icons.pie_chart,
-                size: 32,
-              ),
-              label: const Text('Stats'),
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                textStyle: const TextStyle(fontSize: 20),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/stats');
-              },
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              icon: const Icon(
-                Icons.timer_outlined,
-                size: 32,
-              ),
-              label: const Text('Samples'),
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                textStyle: const TextStyle(fontSize: 20),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/samples');
-              },
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              icon: const Icon(
-                Icons.psychology,
-                size: 32,
-              ),
-              label: const Text('Insights'),
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                textStyle: const TextStyle(fontSize: 20),
-              ),
-              onPressed: () {
-                Navigator.pushNamed(context, '/web');
-              },
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              icon: const Icon(
-                Icons.task_outlined,
-                size: 32,
-              ),
-              label: const Text('Test Post Sensor Data'),
-              style: ElevatedButton.styleFrom(
-                minimumSize: const Size.fromHeight(50),
-                padding:
-                const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                textStyle: const TextStyle(fontSize: 20),
-              ),
-              onPressed: () {
-                SahhaFlutter.postSensorData();
-              },
-            ),
-          ]),
-        ));
+          ),
+          if (isDeprecated) ...[
+            const SizedBox(width: 8),
+            const _DeprecatedBadge(),
+          ],
+        ],
+      ),
+      subtitle: Text(
+        subtitle,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      trailing:
+          trailing ??
+          Icon(Icons.chevron_right, color: theme.colorScheme.onSurfaceVariant),
+    );
+  }
+}
+
+/// Marks the screens backed by deprecated plugin APIs (getStats, getSamples).
+class _DeprecatedBadge extends StatelessWidget {
+  const _DeprecatedBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Text(
+        'deprecated',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+          fontSize: 10,
+        ),
+      ),
+    );
   }
 }

--- a/example/lib/Views/ProfileView.dart
+++ b/example/lib/Views/ProfileView.dart
@@ -1,37 +1,47 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:sahha_flutter/sahha_flutter.dart';
+import 'package:sahha_flutter_example/widgets/response_sheet.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:selectpicker/models/select_picker_item.dart';
-import 'package:selectpicker/selectpicker.dart';
-import 'package:selectpicker/styles/input_style.dart';
 
+/// Exercises `postDemographic` and `getDemographic`.
 class ProfileView extends StatefulWidget {
   const ProfileView({super.key});
 
   @override
-  ProfileState createState() => ProfileState();
+  State<ProfileView> createState() => ProfileState();
 }
 
 class ProfileState extends State<ProfileView> {
-  // Replace age with birthDate
+  /// Values posted to the API, paired with their display labels.
+  static const List<DropdownMenuEntry<String>> genderEntries = [
+    DropdownMenuEntry(value: 'male', label: 'Male'),
+    DropdownMenuEntry(value: 'female', label: 'Female'),
+    DropdownMenuEntry(value: 'gender diverse', label: 'Gender Diverse'),
+  ];
+
   String birthDate = ''; // "YYYY-MM-DD"
   DateTime? birthDateValue;
-
   String gender = '';
+
+  bool _isSaving = false;
+  bool _isFetching = false;
 
   @override
   void initState() {
     super.initState();
 
     SahhaFlutter.getDemographic()
-        .then((value) => debugPrint(value))
-        .catchError((error, stackTrace) => debugPrint(error.toString()));
+        .then((value) => debugPrint('Get Demographic Result: $value'))
+        .catchError(
+          (error, stackTrace) => debugPrint('Get Demographic Error: $error'),
+        );
 
     getPrefs();
   }
 
-  void getPrefs() async {
+  // 'birthDate' / 'gender' keys are kept as-is for backward compatibility.
+  Future<void> getPrefs() async {
     final prefs = await SharedPreferences.getInstance();
 
     final storedBirthDate = prefs.getString('birthDate') ?? '';
@@ -44,14 +54,22 @@ class ProfileState extends State<ProfileView> {
       }
     }
 
+    // Older builds stored the display label ("Male"), so normalise before
+    // handing the value to the dropdown.
+    final storedGender = (prefs.getString('gender') ?? '').toLowerCase();
+    final knownGender = genderEntries.any((e) => e.value == storedGender)
+        ? storedGender
+        : '';
+
+    if (!mounted) return;
     setState(() {
       birthDate = storedBirthDate;
       birthDateValue = parsed;
-      gender = (prefs.getString('gender') ?? '');
+      gender = knownGender;
     });
   }
 
-  void setPrefs() async {
+  Future<void> setPrefs() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('birthDate', birthDate);
     await prefs.setString('gender', gender);
@@ -59,7 +77,8 @@ class ProfileState extends State<ProfileView> {
 
   Future<void> pickBirthDate(BuildContext context) async {
     final now = DateTime.now();
-    final initial = birthDateValue ?? DateTime(now.year - 25, now.month, now.day);
+    final initial =
+        birthDateValue ?? DateTime(now.year - 25, now.month, now.day);
 
     final selected = await showDatePicker(
       context: context,
@@ -68,7 +87,7 @@ class ProfileState extends State<ProfileView> {
       lastDate: now,
     );
 
-    if (selected == null) return;
+    if (selected == null || !mounted) return;
 
     final formatted = DateFormat('yyyy-MM-dd').format(selected);
     setState(() {
@@ -77,13 +96,12 @@ class ProfileState extends State<ProfileView> {
     });
   }
 
-  void onTapSave(BuildContext context) {
+  Future<void> onTapSave() async {
     if (birthDate.isEmpty) {
-      showAlertDialog(context, 'MISSING INFO', "You need to input a BIRTH DATE");
-      return;
+      return _showMissingInfo('You need to input a BIRTH DATE');
     }
 
-    // Basic validation: ensure it's parseable and looks like YYYY-MM-DD
+    // Basic validation: ensure it's parseable and looks like YYYY-MM-DD.
     DateTime? parsed;
     try {
       parsed = DateTime.parse(birthDate);
@@ -91,141 +109,155 @@ class ProfileState extends State<ProfileView> {
       parsed = null;
     }
     if (parsed == null || birthDate.length != 10) {
-      showAlertDialog(context, 'MISSING INFO', "BIRTH DATE must be YYYY-MM-DD");
-      return;
+      return _showMissingInfo('BIRTH DATE must be YYYY-MM-DD');
     }
 
     if (gender.isEmpty) {
-      showAlertDialog(context, 'MISSING INFO', "You need to input a GENDER");
-      return;
+      return _showMissingInfo('You need to input a GENDER');
     }
 
-    setPrefs();
+    setState(() => _isSaving = true);
+    await setPrefs();
 
-    final demographic = {
-      'gender': gender,
-      'birthDate': birthDate,
-    };
+    final demographic = {'gender': gender, 'birthDate': birthDate};
 
-    SahhaFlutter.postDemographic(demographic).then((success) {
-      debugPrint(success.toString());
-      showAlertDialog(context, "SAVE", success.toString());
-    }).catchError((error, stackTrace) {
-      debugPrint(error.toString());
-      showAlertDialog(context, "SAVE", error.toString());
-    });
-  }
+    bool? success;
+    Object? failure;
+    try {
+      success = await SahhaFlutter.postDemographic(demographic);
+      debugPrint('Post Demographic Result: $success');
+    } catch (error) {
+      failure = error;
+      debugPrint('Post Demographic Error: $error');
+    }
 
-  void onTapFetch(BuildContext context) {
-    SahhaFlutter.getDemographic().then((value) {
-      debugPrint(value);
-      showAlertDialog(context, "FETCH", value ?? "empty");
-    }).catchError((error, stackTrace) {
-      debugPrint(error.toString());
-      showAlertDialog(context, "FETCH", error.toString());
-    });
-  }
+    if (!mounted) return;
+    setState(() => _isSaving = false);
 
-  void showAlertDialog(BuildContext context, String title, String message) {
-    final alert = AlertDialog(
-      title: Text(title),
-      content: Text(message),
-      actions: <Widget>[
-        TextButton(
-          child: const Text('OK'),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ],
+    await showResponseSheet(
+      context,
+      title: failure == null ? 'Saved' : 'Save failed',
+      subtitle: 'SahhaFlutter.postDemographic',
+      body: (failure ?? success).toString(),
+      isError: failure != null,
     );
+  }
 
-    showDialog(
-      context: context,
-      builder: (BuildContext context) => alert,
+  Future<void> onTapFetch() async {
+    setState(() => _isFetching = true);
+
+    String? value;
+    Object? failure;
+    try {
+      value = await SahhaFlutter.getDemographic();
+      debugPrint('Get Demographic Result: $value');
+    } catch (error) {
+      failure = error;
+      debugPrint('Get Demographic Error: $error');
+    }
+
+    if (!mounted) return;
+    setState(() => _isFetching = false);
+
+    await showResponseSheet(
+      context,
+      title: failure == null ? 'Demographic' : 'Fetch failed',
+      subtitle: 'SahhaFlutter.getDemographic',
+      body: failure != null
+          ? failure.toString()
+          : tryPrettyJson(value ?? 'empty'),
+      isError: failure != null,
+    );
+  }
+
+  Future<void> _showMissingInfo(String message) {
+    return showResponseSheet(
+      context,
+      title: 'Missing info',
+      body: message,
+      isError: true,
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    final birthDateLabel = birthDate.isEmpty ? 'BIRTH DATE' : birthDate;
+    final theme = Theme.of(context);
+    final busy = _isSaving || _isFetching;
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Profile'),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(40),
-        child: Center(
-          child: Column(
-            children: <Widget>[
-              const Spacer(),
-              const Icon(Icons.person, size: 64),
-              const SizedBox(height: 20),
-
-              // Birth date picker field
-              InkWell(
-                onTap: () => pickBirthDate(context),
-                child: InputDecorator(
-                  decoration: const InputDecoration(
-                    labelText: 'BIRTH DATE',
-                    border: OutlineInputBorder(),
+      appBar: AppBar(title: const Text('Profile')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  InkWell(
+                    onTap: () => pickBirthDate(context),
+                    borderRadius: BorderRadius.circular(12),
+                    child: InputDecorator(
+                      decoration: const InputDecoration(
+                        labelText: 'BIRTH DATE',
+                        suffixIcon: Icon(Icons.calendar_today, size: 18),
+                      ),
+                      child: Text(
+                        birthDate.isEmpty ? 'Not set' : birthDate,
+                        style: birthDate.isEmpty
+                            ? theme.textTheme.bodyMedium?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              )
+                            : theme.textTheme.bodyMedium,
+                      ),
+                    ),
                   ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(birthDateLabel),
-                      const Icon(Icons.calendar_today),
-                    ],
+                  const SizedBox(height: 16),
+                  DropdownMenu<String>(
+                    initialSelection: gender.isEmpty ? null : gender,
+                    label: const Text('GENDER'),
+                    hintText: 'Not set',
+                    enableSearch: false,
+                    requestFocusOnTap: false,
+                    expandedInsets: EdgeInsets.zero,
+                    dropdownMenuEntries: genderEntries,
+                    onSelected: (value) {
+                      if (value == null) return;
+                      setState(() => gender = value);
+                    },
                   ),
-                ),
-              ),
-
-              const SizedBox(height: 20),
-
-              SelectPicker(
-                hint: gender.isEmpty ? "GENDER" : gender,
-                list: [
-                  SelectPickerItem("Male", "male", null),
-                  SelectPickerItem("Female", "female", null),
-                  SelectPickerItem("Gender Diverse", "gender diverse", null),
                 ],
-                selectFirst: false,
-                showId: false,
-                onSelect: (value) {
-                  setState(() {
-                    // Use value.value if you want "male/female" instead of title
-                    gender = value.title.toString();
-                  });
-                },
-                selectPickerInputStyle: SelectPickerInputStyle(),
-                initialItem: gender,
               ),
-
-              const SizedBox(height: 40),
-
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size.fromHeight(40),
-                  padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                  textStyle: const TextStyle(fontSize: 16),
-                ),
-                onPressed: () => onTapSave(context),
-                child: const Text('SAVE'),
-              ),
-
-              const SizedBox(height: 40),
-
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size.fromHeight(40),
-                  padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                  textStyle: const TextStyle(fontSize: 16),
-                ),
-                onPressed: () => onTapFetch(context),
-                child: const Text('FETCH'),
-              ),
-            ],
+            ),
           ),
-        ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: busy ? null : onTapSave,
+            child: _busyLabel(context, busy: _isSaving, label: 'SAVE'),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton(
+            onPressed: busy ? null : onTapFetch,
+            child: _busyLabel(context, busy: _isFetching, label: 'FETCH'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static Widget _busyLabel(
+    BuildContext context, {
+    required bool busy,
+    required String label,
+  }) {
+    if (!busy) return Text(label);
+    return SizedBox(
+      height: 20,
+      width: 20,
+      child: CircularProgressIndicator(
+        strokeWidth: 2,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
       ),
     );
   }

--- a/example/lib/Views/SamplesView.dart
+++ b/example/lib/Views/SamplesView.dart
@@ -1,120 +1,691 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:sahha_flutter/sahha_flutter.dart';
-import 'package:selectpicker/models/select_picker_item.dart';
-import 'package:selectpicker/selectpicker.dart';
-import 'package:selectpicker/styles/input_style.dart';
+import 'package:sahha_flutter_example/widgets/date_range_selector.dart';
+import 'package:sahha_flutter_example/widgets/response_sheet.dart';
+import 'package:sahha_flutter_example/widgets/sensor_groups.dart';
+import 'package:sahha_flutter_example/widgets/sensor_picker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+final DateFormat _dayHeaderFormat = DateFormat('EEEE d MMMM');
+final DateFormat _timeFormat = DateFormat('HH:mm');
+final NumberFormat _numberFormat = NumberFormat.decimalPattern();
+
+/// Samples beyond this are only available through the raw payload: rendering
+/// every row of a busy day (heart rate, steps) would stall the list.
+const int _maxRenderedSamples = 300;
+
+/// Test harness for the deprecated `getSamples` API.
+///
+/// Kept so the raw on-device samples can be regression tested against the
+/// server-processed values returned by `getBiomarkers`.
 class SamplesView extends StatefulWidget {
-  const SamplesView({Key? key}) : super(key: key);
+  const SamplesView({super.key});
 
   @override
   SamplesState createState() => SamplesState();
 }
 
 class SamplesState extends State<SamplesView> {
-  String sensor = '';
+  static const String _sensorPrefsKey = 'samples.sensor';
+
+  SahhaSensor? _sensor = SahhaSensor.steps;
+  late DateTime _start;
+  late DateTime _end;
+  bool _isLoading = false;
+  String? _raw;
+  String? _error;
+  List<_Sample>? _samples;
 
   @override
   void initState() {
     super.initState();
+
+    final now = DateTime.now();
+    _end = now;
+    _start = now.subtract(const Duration(hours: 24));
+
+    _restoreSensor();
   }
 
-  onTapGetSamples(BuildContext context) {
-    // The demo intentionally shows the deprecated APIs alongside getBiomarkers.
-    // ignore: deprecated_member_use
-    SahhaFlutter.getSamples(
-          sensor: SahhaSensor.values.firstWhere(
-            (element) => element.name == sensor,
-          ),
-          startDateTime: DateTime.timestamp().subtract(const Duration(days: 1)),
-          endDateTime: DateTime.timestamp(),
-        )
-        .then((value) {
-          List<dynamic> data = jsonDecode(value);
-          debugPrint(data.firstOrNull?.toString());
-          const encoder = JsonEncoder.withIndent('      ');
-          final prettyJson = encoder.convert(data);
-          showAlertDialog(context, "SAMPLES", prettyJson);
-        })
-        .catchError((error, stackTrace) {
-          showAlertDialog(context, "Error", error.toString());
-          return null;
-        });
+  Future<void> _restoreSensor() async {
+    final prefs = await SharedPreferences.getInstance();
+    final name = prefs.getString(_sensorPrefsKey);
+    if (name == null) return;
+    // Tolerate sensors that were removed or renamed since the value was saved.
+    final restored = _sensorNamed(name);
+    if (restored == null || !mounted) return;
+    setState(() => _sensor = restored);
   }
 
-  showAlertDialog(BuildContext context, String title, String message) {
-    AlertDialog alert = AlertDialog(
-      title: Text(title),
-      content: SingleChildScrollView(child: Text(message)),
-      actions: <Widget>[
-        TextButton(
-          child: const Text('OK'),
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-        ),
-      ],
-    );
+  Future<void> _saveSensor(SahhaSensor sensor) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_sensorPrefsKey, sensor.name);
+  }
 
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return alert;
-      },
+  SahhaSensor? _sensorNamed(String name) {
+    for (final sensor in SahhaSensor.values) {
+      if (sensor.name == name) return sensor;
+    }
+    return null;
+  }
+
+  Future<void> _pickSensor() async {
+    final picked = await showSensorPicker(context, selected: _sensor);
+    if (picked == null || !mounted) return;
+    setState(() => _sensor = picked);
+    await _saveSensor(picked);
+  }
+
+  Future<void> _getSamples() async {
+    final sensor = _sensor;
+    if (sensor == null || _isLoading) return;
+
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      // The demo intentionally exercises the deprecated APIs alongside
+      // getBiomarkers.
+      // ignore: deprecated_member_use
+      final raw = await SahhaFlutter.getSamples(
+        sensor: sensor,
+        startDateTime: _start,
+        endDateTime: _end,
+      );
+      debugPrint(raw);
+      final samples = _parseSamples(raw);
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _raw = raw;
+        _samples = samples;
+      });
+    } catch (error) {
+      debugPrint(error.toString());
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _raw = null;
+        _samples = null;
+        _error = error.toString();
+      });
+      showResponseSheet(
+        context,
+        title: 'GET SAMPLES',
+        body: error.toString(),
+        subtitle: sensor.name,
+        isError: true,
+      );
+    }
+  }
+
+  void _showRawJson() {
+    final raw = _raw;
+    if (raw == null) return;
+    final count = _samples?.length ?? 0;
+    showResponseSheet(
+      context,
+      title: 'GET SAMPLES',
+      body: tryPrettyJson(raw),
+      subtitle: '$count ${count == 1 ? 'entry' : 'entries'}',
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sensor = _sensor;
+
     return Scaffold(
       appBar: AppBar(title: const Text('Samples')),
-      body: Padding(
-        padding: const EdgeInsets.all(40),
-        child: Center(
-          child: Column(
-            children: <Widget>[
-              const Spacer(),
-              const Icon(Icons.timer_outlined, size: 64),
-              const SizedBox(height: 20),
-              SelectPicker(
-                hint: sensor.isEmpty ? "SENSOR" : sensor,
-                list: [
-                  for (var sensor in SahhaSensor.values)
-                    SelectPickerItem(sensor.name, sensor.name, null),
-                ],
-                selectFirst: false,
-                showId: false,
-                onSelect: (value) {
-                  setState(() {
-                    sensor = value.title;
-                    debugPrint(sensor);
-                  });
-                },
-                selectPickerInputStyle: SelectPickerInputStyle(),
-                initialItem: sensor,
-              ),
-              const SizedBox(height: 40),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size.fromHeight(40),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 40,
-                    vertical: 20,
-                  ),
-                  textStyle: const TextStyle(fontSize: 16),
-                ),
-                onPressed: () {
-                  onTapGetSamples(context);
-                },
-                child: const Text('GET SAMPLES'),
-              ),
-              const SizedBox(height: 40),
-            ],
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+        children: [
+          const _DeprecationCallout(),
+          const SizedBox(height: 20),
+          const _SectionHeader('Query'),
+          const SizedBox(height: 12),
+          _SensorField(sensor: sensor, onTap: _isLoading ? null : _pickSensor),
+          const SizedBox(height: 12),
+          DateRangeSelector(
+            start: _start,
+            end: _end,
+            onChanged: (start, end) => setState(() {
+              _start = start;
+              _end = end;
+            }),
           ),
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: _isLoading || sensor == null ? null : _getSamples,
+              child: _isLoading
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('GET SAMPLES'),
+            ),
+          ),
+          const SizedBox(height: 24),
+          ..._results(theme),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _results(ThemeData theme) {
+    final error = _error;
+    if (error != null) {
+      return [
+        _InfoCard(
+          icon: Icons.error_outline,
+          color: theme.colorScheme.error,
+          title: 'GET SAMPLES failed',
+          message: error,
+          action: TextButton(
+            onPressed: () => showResponseSheet(
+              context,
+              title: 'GET SAMPLES',
+              body: error,
+              subtitle: _sensor?.name,
+              isError: true,
+            ),
+            child: const Text('Details'),
+          ),
+        ),
+      ];
+    }
+
+    final samples = _samples;
+    if (samples == null || _raw == null) return const [];
+
+    final shown = samples.length > _maxRenderedSamples
+        ? samples.sublist(0, _maxRenderedSamples)
+        : samples;
+
+    // Group by calendar day, keeping the (already descending) sample order.
+    final byDay = <String, List<_Sample>>{};
+    for (final sample in shown) {
+      final start = sample.start;
+      final day = start == null
+          ? 'Unknown date'
+          : _dayHeaderFormat.format(start);
+      byDay.putIfAbsent(day, () => []).add(sample);
+    }
+
+    return [
+      Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${samples.length} '
+                  '${samples.length == 1 ? 'sample' : 'samples'}',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                if (byDay.isNotEmpty)
+                  Text(
+                    '${byDay.length} ${byDay.length == 1 ? 'day' : 'days'}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          TextButton(onPressed: _showRawJson, child: const Text('Raw JSON')),
+        ],
+      ),
+      if (samples.isEmpty)
+        _InfoCard(
+          icon: Icons.inbox_outlined,
+          color: theme.colorScheme.onSurfaceVariant,
+          title: 'No samples returned',
+          message:
+              'Nothing was recorded for ${_sensor?.name ?? 'this sensor'} in '
+              'this date range. Check the sensor is enabled in Permissions and '
+              'that the device has data for the period.',
+        )
+      else ...[
+        for (final entry in byDay.entries) ...[
+          Padding(
+            padding: const EdgeInsets.only(top: 16, bottom: 4),
+            child: Text(
+              entry.key,
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.primary,
+              ),
+            ),
+          ),
+          const Divider(height: 1),
+          for (final sample in entry.value) ...[
+            _SampleRow(sample: sample),
+            const Divider(height: 1),
+          ],
+        ],
+        if (shown.length < samples.length)
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: Text(
+              'Showing ${shown.length} of ${samples.length} — open Raw JSON '
+              'for the full payload',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+      ],
+    ];
+  }
+}
+
+/// A single `getSamples` entry, parsed defensively: field names and value types
+/// differ slightly between the iOS and Android bridges.
+class _Sample {
+  _Sample({
+    required this.value,
+    required this.valueText,
+    required this.unit,
+    required this.start,
+    required this.end,
+    required this.rawStart,
+    required this.source,
+    required this.recordingMethod,
+    required this.statCount,
+  });
+
+  final double? value;
+  final String? valueText;
+  final String? unit;
+  final DateTime? start;
+  final DateTime? end;
+  final String? rawStart;
+  final String? source;
+  final String? recordingMethod;
+  final int statCount;
+
+  String get timeLabel {
+    final start = this.start;
+    if (start == null) return rawStart ?? 'Unknown time';
+    final end = this.end;
+    if (end == null || end.isAtSameMomentAs(start)) {
+      return _timeFormat.format(start);
+    }
+    return '${_timeFormat.format(start)}–${_timeFormat.format(end)}';
+  }
+
+  String get valueLabel {
+    final value = this.value;
+    final text = value != null
+        ? _numberFormat.format(value)
+        : (valueText ?? '—');
+    final unit = this.unit;
+    return unit == null || unit.isEmpty ? text : '$text $unit';
+  }
+}
+
+List<_Sample> _parseSamples(String raw) {
+  final samples = <_Sample>[];
+  for (final map in _decodeEntries(raw, const ['samples', 'data', 'items'])) {
+    final value = _pick(map, const ['value', 'count']);
+    final stats = map['stats'];
+    samples.add(
+      _Sample(
+        value: _asDouble(value),
+        valueText: _asText(value),
+        unit: _asText(_pick(map, const ['unit', 'unitName'])),
+        start: _asDateTime(
+          _pick(map, const ['startDateTime', 'startDate', 'start']),
+        ),
+        end: _asDateTime(_pick(map, const ['endDateTime', 'endDate', 'end'])),
+        rawStart: _asText(
+          _pick(map, const ['startDateTime', 'startDate', 'start']),
+        ),
+        source: _asText(_pick(map, const ['source', 'sourceName', 'device'])),
+        recordingMethod: _asText(
+          _pick(map, const ['recordingMethod', 'recordingType']),
+        ),
+        statCount: stats is Iterable ? stats.length : 0,
+      ),
+    );
+  }
+  // Most recent sample first.
+  samples.sort((a, b) {
+    final aStart = a.start;
+    final bStart = b.start;
+    if (aStart == null && bStart == null) return 0;
+    if (aStart == null) return 1;
+    if (bStart == null) return -1;
+    return bStart.compareTo(aStart);
+  });
+  return samples;
+}
+
+class _SampleRow extends StatelessWidget {
+  const _SampleRow({required this.sample});
+
+  final _Sample sample;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final chips = <String>[
+      if (sample.source != null) sample.source!,
+      if (sample.recordingMethod != null) sample.recordingMethod!,
+      if (sample.statCount > 0) '${sample.statCount} stats',
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(sample.timeLabel, style: theme.textTheme.bodyMedium),
+                if (chips.isNotEmpty) ...[
+                  const SizedBox(height: 6),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: [
+                      for (final chip in chips) _MetaChip(label: chip),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Text(
+            sample.valueLabel,
+            textAlign: TextAlign.right,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetaChip extends StatelessWidget {
+  const _MetaChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
         ),
       ),
     );
   }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      title,
+      style: theme.textTheme.labelLarge?.copyWith(
+        color: theme.colorScheme.primary,
+      ),
+    );
+  }
+}
+
+class _SensorField extends StatelessWidget {
+  const _SensorField({required this.sensor, required this.onTap});
+
+  final SahhaSensor? sensor;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sensor = this.sensor;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: InputDecorator(
+        decoration: const InputDecoration(
+          labelText: 'Sensor',
+          border: OutlineInputBorder(),
+          contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          suffixIcon: Icon(Icons.expand_more, size: 20),
+        ),
+        child: sensor == null
+            ? Text(
+                'Select a sensor',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              )
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(sensor.name, style: theme.textTheme.bodyMedium),
+                  Text(
+                    sensorGroupOf(sensor),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+class _DeprecationCallout extends StatelessWidget {
+  const _DeprecationCallout();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 12, 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.tertiaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.info_outline,
+            size: 20,
+            color: theme.colorScheme.onTertiaryContainer,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'getSamples is deprecated',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: theme.colorScheme.onTertiaryContainer,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'New integrations should use getBiomarkers. This screen '
+                  'stays so the deprecated API can be regression tested.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onTertiaryContainer,
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: () =>
+                        Navigator.pushNamed(context, '/biomarkers'),
+                    child: const Text('Open Biomarkers'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoCard extends StatelessWidget {
+  const _InfoCard({
+    required this.icon,
+    required this.color,
+    required this.title,
+    required this.message,
+    this.action,
+  });
+
+  final IconData icon;
+  final Color color;
+  final String title;
+  final String message;
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 20, color: color),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: theme.textTheme.titleSmall),
+                const SizedBox(height: 4),
+                Text(
+                  message,
+                  maxLines: 6,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                if (action != null)
+                  Align(alignment: Alignment.centerLeft, child: action),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Decodes a bridge payload into a list of string-keyed maps, tolerating a
+/// single object, a wrapper object and malformed JSON.
+List<Map<String, dynamic>> _decodeEntries(
+  String raw,
+  List<String> wrapperKeys,
+) {
+  dynamic decoded;
+  try {
+    decoded = jsonDecode(raw);
+  } catch (_) {
+    return const [];
+  }
+  if (decoded is Map) {
+    for (final key in wrapperKeys) {
+      final wrapped = decoded[key];
+      if (wrapped is List) {
+        decoded = wrapped;
+        break;
+      }
+    }
+  }
+  if (decoded is Map) {
+    return [decoded.map((key, value) => MapEntry(key.toString(), value))];
+  }
+  if (decoded is! List) return const [];
+  return [
+    for (final entry in decoded)
+      if (entry is Map)
+        entry.map((key, value) => MapEntry(key.toString(), value)),
+  ];
+}
+
+dynamic _pick(Map<String, dynamic> map, List<String> keys) {
+  for (final key in keys) {
+    final value = map[key];
+    if (value != null) return value;
+  }
+  return null;
+}
+
+String? _asText(dynamic value) {
+  if (value == null || value is Iterable || value is Map) return null;
+  final text = value.toString().trim();
+  return text.isEmpty ? null : text;
+}
+
+double? _asDouble(dynamic value) {
+  if (value is num) return value.toDouble();
+  if (value is String) return double.tryParse(value.trim());
+  return null;
+}
+
+DateTime? _asDateTime(dynamic value) {
+  if (value is num) {
+    // Seconds or milliseconds since epoch, depending on the platform.
+    final millis = value > 100000000000
+        ? value.toInt()
+        : (value * 1000).toInt();
+    return DateTime.fromMillisecondsSinceEpoch(millis).toLocal();
+  }
+  if (value is! String) return null;
+  var text = value.trim();
+  if (text.isEmpty) return null;
+  // Android serialises ZonedDateTime with a trailing zone id, which
+  // DateTime.parse rejects: 2026-05-21T09:00+12:00[Pacific/Auckland]
+  final zoneIndex = text.indexOf('[');
+  if (zoneIndex > 0) text = text.substring(0, zoneIndex);
+  return DateTime.tryParse(text)?.toLocal();
 }

--- a/example/lib/Views/SamplesView.dart
+++ b/example/lib/Views/SamplesView.dart
@@ -22,6 +22,8 @@ class SamplesState extends State<SamplesView> {
   }
 
   onTapGetSamples(BuildContext context) {
+    // The demo intentionally shows the deprecated APIs alongside getBiomarkers.
+    // ignore: deprecated_member_use
     SahhaFlutter.getSamples(
             sensor: SahhaSensor.values
                 .firstWhere((element) => element.name == sensor),

--- a/example/lib/Views/SamplesView.dart
+++ b/example/lib/Views/SamplesView.dart
@@ -25,21 +25,23 @@ class SamplesState extends State<SamplesView> {
     // The demo intentionally shows the deprecated APIs alongside getBiomarkers.
     // ignore: deprecated_member_use
     SahhaFlutter.getSamples(
-            sensor: SahhaSensor.values
-                .firstWhere((element) => element.name == sensor),
-            startDateTime:
-                DateTime.timestamp().subtract(const Duration(days: 1)),
-            endDateTime: DateTime.timestamp())
+          sensor: SahhaSensor.values.firstWhere(
+            (element) => element.name == sensor,
+          ),
+          startDateTime: DateTime.timestamp().subtract(const Duration(days: 1)),
+          endDateTime: DateTime.timestamp(),
+        )
         .then((value) {
-      List<dynamic> data = jsonDecode(value);
-      debugPrint(data.firstOrNull?.toString());
-      const encoder = JsonEncoder.withIndent('      ');
-      final prettyJson = encoder.convert(data);
-      showAlertDialog(context, "SAMPLES", prettyJson);
-    }).catchError((error, stackTrace) {
-      showAlertDialog(context, "Error", error.toString());
-      return null;
-    });
+          List<dynamic> data = jsonDecode(value);
+          debugPrint(data.firstOrNull?.toString());
+          const encoder = JsonEncoder.withIndent('      ');
+          final prettyJson = encoder.convert(data);
+          showAlertDialog(context, "SAMPLES", prettyJson);
+        })
+        .catchError((error, stackTrace) {
+          showAlertDialog(context, "Error", error.toString());
+          return null;
+        });
   }
 
   showAlertDialog(BuildContext context, String title, String message) {
@@ -67,25 +69,20 @@ class SamplesState extends State<SamplesView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Samples'),
-      ),
+      appBar: AppBar(title: const Text('Samples')),
       body: Padding(
         padding: const EdgeInsets.all(40),
         child: Center(
           child: Column(
             children: <Widget>[
               const Spacer(),
-              const Icon(
-                Icons.timer_outlined,
-                size: 64,
-              ),
+              const Icon(Icons.timer_outlined, size: 64),
               const SizedBox(height: 20),
               SelectPicker(
                 hint: sensor.isEmpty ? "SENSOR" : sensor,
                 list: [
                   for (var sensor in SahhaSensor.values)
-                    SelectPickerItem(sensor.name, sensor.name, null)
+                    SelectPickerItem(sensor.name, sensor.name, null),
                 ],
                 selectFirst: false,
                 showId: false,
@@ -102,8 +99,10 @@ class SamplesState extends State<SamplesView> {
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   minimumSize: const Size.fromHeight(40),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 40,
+                    vertical: 20,
+                  ),
                   textStyle: const TextStyle(fontSize: 16),
                 ),
                 onPressed: () {

--- a/example/lib/Views/ScoresView.dart
+++ b/example/lib/Views/ScoresView.dart
@@ -1,133 +1,689 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:sahha_flutter/sahha_flutter.dart';
+import 'package:sahha_flutter_example/widgets/date_range_selector.dart';
+import 'package:sahha_flutter_example/widgets/response_sheet.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+const _typesPrefsKey = 'scores.types';
+
+const _defaultScoreTypes = <SahhaScoreType>{
+  SahhaScoreType.activity,
+  SahhaScoreType.sleep,
+  SahhaScoreType.wellbeing,
+};
+
+/// Test harness for [SahhaFlutter.getScores]: pick score types and a date
+/// range, then inspect the parsed response inline.
 class ScoresView extends StatefulWidget {
-  const ScoresView({Key? key}) : super(key: key);
+  const ScoresView({super.key});
 
   @override
-  ScoresState createState() => ScoresState();
+  State<ScoresView> createState() => ScoresState();
 }
 
 class ScoresState extends State<ScoresView> {
+  static final DateFormat _dateTimeFormat = DateFormat('d MMM, HH:mm');
+
+  final Set<SahhaScoreType> _types = {..._defaultScoreTypes};
+
+  DateTime _start = DateTime.now().subtract(const Duration(days: 7));
+  DateTime _end = DateTime.now();
+
+  bool _isLoading = false;
+
+  /// Raw response of the last successful call, `null` before the first one.
+  String? _rawResponse;
+  List<_ScoreEntry> _entries = const [];
+  DateTime? _queriedStart;
+  DateTime? _queriedEnd;
+
   @override
   void initState() {
     super.initState();
 
-    getPrefs();
+    _restoreSelections();
   }
 
-  void getPrefs() async {
+  /// Selection in enum order so the request is stable regardless of the order
+  /// the user tapped things in.
+  List<SahhaScoreType> get _selectedTypes => [
+    for (final type in SahhaScoreType.values)
+      if (_types.contains(type)) type,
+  ];
+
+  Future<void> _restoreSelections() async {
     final prefs = await SharedPreferences.getInstance();
-    setState(() {});
+    final stored = prefs.getStringList(_typesPrefsKey);
+    if (stored == null) return;
+    final byName = {for (final type in SahhaScoreType.values) type.name: type};
+    final restored = <SahhaScoreType>{
+      for (final name in stored)
+        if (byName[name] case final type?) type,
+    };
+    // Every stored name is unknown (renamed enum): keep the defaults.
+    if (restored.isEmpty && stored.isNotEmpty) return;
+    if (!mounted) return;
+    setState(() {
+      _types
+        ..clear()
+        ..addAll(restored);
+    });
   }
 
-  void setPrefs() async {
+  Future<void> _persistSelections() async {
     final prefs = await SharedPreferences.getInstance();
-    setState(() {});
+    await prefs.setStringList(_typesPrefsKey, [
+      for (final type in _selectedTypes) type.name,
+    ]);
   }
 
-  onTapGetScores(BuildContext context, bool isDaily) {
-    if (isDaily) {
-      SahhaFlutter.getScores(types: [
-        SahhaScoreType.activity,
-        SahhaScoreType.sleep,
-        SahhaScoreType.wellbeing
-      ], startDateTime: DateTime.now(), endDateTime: DateTime.now())
-          .then((value) {
-        final data = jsonDecode(value);
-        debugPrint(data.toString());
-        showAlertDialog(context, value);
-      }).catchError((error, stackTrace) => {debugPrint(error.toString())});
-    } else {
-      var week = DateTime.now().subtract(const Duration(days: 7));
-      SahhaFlutter.getScores(types: [
-        SahhaScoreType.activity,
-        SahhaScoreType.sleep,
-        SahhaScoreType.wellbeing
-      ], startDateTime: week, endDateTime: DateTime.now())
-          .then((value) {
-        final data = jsonDecode(value);
-        debugPrint(data.toString());
-        showAlertDialog(context, value);
-      }).catchError((error, stackTrace) => {debugPrint(error.toString())});
+  void _toggleType(SahhaScoreType type, bool selected) {
+    setState(() {
+      if (selected) {
+        _types.add(type);
+      } else {
+        _types.remove(type);
+      }
+    });
+    _persistSelections();
+  }
+
+  Future<void> _getScores() async {
+    if (_types.isEmpty || _isLoading) return;
+
+    final start = _start;
+    final end = _end;
+    setState(() => _isLoading = true);
+
+    try {
+      final raw = await SahhaFlutter.getScores(
+        types: _selectedTypes,
+        startDateTime: start,
+        endDateTime: end,
+      );
+      debugPrint('GET SCORES: $raw');
+      final entries = _parseEntries(raw);
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _rawResponse = raw;
+        _entries = entries;
+        _queriedStart = start;
+        _queriedEnd = end;
+      });
+    } catch (error) {
+      debugPrint('GET SCORES error: $error');
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _rawResponse = null;
+        _entries = const [];
+        _queriedStart = null;
+        _queriedEnd = null;
+      });
+      await showResponseSheet(
+        context,
+        title: 'GET SCORES',
+        body: error.toString(),
+        subtitle: 'Request failed — authenticate the profile and try again',
+        isError: true,
+      );
     }
   }
 
-  showAlertDialog(BuildContext context, String value) {
-    AlertDialog alert = AlertDialog(
-      title: const Text('SCORES'),
-      content: SingleChildScrollView(child: Text(value)),
-      actions: <Widget>[
-        TextButton(
-          child: const Text('OK'),
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-        ),
-      ],
-    );
-
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return alert;
-      },
-    );
+  List<_ScoreEntry> _parseEntries(String raw) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } catch (error) {
+      debugPrint('GET SCORES: response was not JSON ($error)');
+      return const [];
+    }
+    if (decoded is! List) return const [];
+    return [
+      for (final item in decoded)
+        if (item is Map) _ScoreEntry(item),
+    ];
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
-        appBar: AppBar(
-          title: const Text('Scores'),
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(40),
-          child: Center(
-            child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  const Spacer(),
-                  const Icon(
-                    Icons.query_stats,
-                    size: 64,
-                  ),
-                  const SizedBox(height: 20),
-                  const Text('A new score will be available every 6 hours',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(fontSize: 18)),
-                  const SizedBox(height: 20),
-                  const SizedBox(height: 20),
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      minimumSize: const Size.fromHeight(40),
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 40, vertical: 20),
-                      textStyle: const TextStyle(fontSize: 16),
-                    ),
-                    onPressed: () {
-                      onTapGetScores(context, false);
-                    },
-                    child: const Text('GET SCORES PREVIOUS WEEK'),
-                  ),
-                  const SizedBox(height: 20),
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      minimumSize: const Size.fromHeight(40),
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 40, vertical: 20),
-                      textStyle: const TextStyle(fontSize: 16),
-                    ),
-                    onPressed: () {
-                      onTapGetScores(context, true);
-                    },
-                    child: const Text('GET SCORES TODAY'),
-                  ),
-                ]),
+      appBar: AppBar(title: const Text('Scores')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 20, 20, 40),
+        children: [
+          _sectionHeader(theme, 'Score types'),
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            children: [
+              for (final type in SahhaScoreType.values)
+                FilterChip(
+                  label: Text(_prettyLabel(type.name)),
+                  selected: _types.contains(type),
+                  onSelected: (selected) => _toggleType(type, selected),
+                ),
+            ],
           ),
-        ));
+          const SizedBox(height: 24),
+          _sectionHeader(theme, 'Date range'),
+          DateRangeSelector(
+            start: _start,
+            end: _end,
+            onChanged: (start, end) => setState(() {
+              _start = start;
+              _end = end;
+            }),
+          ),
+          const SizedBox(height: 24),
+          if (_types.isEmpty)
+            const Padding(
+              padding: EdgeInsets.only(bottom: 12),
+              child: _InlineHint(
+                message: 'Select at least one score type to run the request.',
+              ),
+            ),
+          FilledButton(
+            onPressed: _types.isNotEmpty && !_isLoading ? _getScores : null,
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48),
+            ),
+            child: _isLoading
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('GET SCORES'),
+          ),
+          ..._buildResults(theme),
+        ],
+      ),
+    );
   }
+
+  Widget _sectionHeader(ThemeData theme, String label) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(
+        label,
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: theme.colorScheme.primary,
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildResults(ThemeData theme) {
+    final raw = _rawResponse;
+    if (raw == null) return const [];
+
+    final start = _queriedStart;
+    final end = _queriedEnd;
+    final range = start != null && end != null
+        ? '${_dateTimeFormat.format(start)} – ${_dateTimeFormat.format(end)}'
+        : null;
+
+    return [
+      const SizedBox(height: 28),
+      const Divider(height: 1),
+      Padding(
+        padding: const EdgeInsets.only(top: 12, bottom: 8),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _entries.length == 1
+                        ? '1 result'
+                        : '${_entries.length} results',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  if (range != null)
+                    Text(
+                      range,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            TextButton(
+              onPressed: () => showResponseSheet(
+                context,
+                title: 'GET SCORES',
+                body: tryPrettyJson(raw),
+                subtitle: '${_entries.length} results',
+              ),
+              child: const Text('Raw JSON'),
+            ),
+          ],
+        ),
+      ),
+      if (_entries.isEmpty)
+        const _EmptyResults()
+      else
+        for (final entry in _entries)
+          _ScoreCard(entry: entry, dateTimeFormat: _dateTimeFormat),
+    ];
+  }
+}
+
+class _ScoreCard extends StatelessWidget {
+  const _ScoreCard({required this.entry, required this.dateTimeFormat});
+
+  final _ScoreEntry entry;
+  final DateFormat dateTimeFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = entry.state;
+    final stateColor = _stateColor(theme, state);
+    final fraction = entry.scoreFraction;
+    final dateLabel = _formatDateTime(dateTimeFormat, entry.scoreDateTime);
+    final factors = entry.factors;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            _prettyLabel(entry.type ?? 'Unknown type'),
+                            style: theme.textTheme.titleMedium,
+                          ),
+                          if (dateLabel != null)
+                            Text(
+                              dateLabel,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    if (state != null)
+                      _StatusChip(
+                        label: _prettyLabel(state),
+                        color: stateColor,
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 14),
+                if (fraction == null)
+                  Text(
+                    'No score value in the response',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  )
+                else
+                  Row(
+                    children: [
+                      Expanded(
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(4),
+                          child: LinearProgressIndicator(
+                            value: fraction,
+                            minHeight: 8,
+                            color: stateColor,
+                            backgroundColor:
+                                theme.colorScheme.surfaceContainerHighest,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Text(
+                        _percentLabel(fraction),
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+          if (factors.isNotEmpty)
+            ExpansionTile(
+              // The card already draws the border and padding, so the tile
+              // stays flush with it whatever the app theme sets.
+              shape: const Border(),
+              collapsedShape: const Border(),
+              childrenPadding: EdgeInsets.zero,
+              expandedCrossAxisAlignment: CrossAxisAlignment.start,
+              tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+              title: Text(
+                'Factors (${factors.length})',
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+              children: [
+                for (final factor in factors) _FactorRow(factor: factor),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FactorRow extends StatelessWidget {
+  const _FactorRow({required this.factor});
+
+  final _ScoreFactor factor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = factor.state;
+    final fraction = factor.scoreFraction;
+    final unit = factor.unit;
+    final value = factor.value;
+    final goal = factor.goal;
+
+    final details = <String>[
+      if (value != null) unit == null ? value : '$value $unit',
+      if (goal != null) 'goal ${unit == null ? goal : '$goal $unit'}',
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _prettyLabel(factor.name ?? 'Unknown factor'),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (details.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      details.join(' · '),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          if (state != null || fraction != null)
+            _StatusChip(
+              label: [
+                if (state != null) _prettyLabel(state),
+                if (fraction != null) _percentLabel(fraction),
+              ].join(' · '),
+              color: _stateColor(theme, state),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineHint extends StatelessWidget {
+  const _InlineHint({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          Icons.info_outline,
+          size: 18,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            message,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyResults extends StatelessWidget {
+  const _EmptyResults();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            Icon(
+              Icons.inbox_outlined,
+              size: 40,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'No scores for this range',
+              style: theme.textTheme.titleSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'Scores are generated from processed sensor data, so they can '
+              'take a while to appear. Check that the profile is '
+              'authenticated, that sensor permissions are granted, and try a '
+              'wider date range.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Shared key-normalising base for the `getScores` payload: keys are lower
+/// cased with underscores stripped so the same getter works whether the
+/// platform returns `scoreDateTime` or `score_date_time`, and every getter
+/// tolerates a missing or unexpectedly typed field.
+class _JsonRow {
+  _JsonRow(Map<Object?, Object?> json)
+    : _fields = {
+        for (final entry in json.entries) _normaliseKey(entry.key): entry.value,
+      };
+
+  final Map<String, Object?> _fields;
+
+  static String _normaliseKey(Object? key) =>
+      key.toString().toLowerCase().replaceAll('_', '');
+
+  Object? raw(String key) => _fields[_normaliseKey(key)];
+
+  String? string(String key) {
+    final value = raw(key);
+    if (value == null) return null;
+    final text = value.toString().trim();
+    return text.isEmpty ? null : text;
+  }
+
+  String? number(String key) {
+    final value = raw(key);
+    if (value == null) return null;
+    if (value is num) return _formatNumber(value);
+    final text = value.toString().trim();
+    return text.isEmpty ? null : text;
+  }
+
+  /// Score values are usually a 0–1 double, but a 0–100 percentage is handled
+  /// too. Returns `null` when the field is missing or not a number.
+  double? fraction(String key) {
+    final value = raw(key);
+    final parsed = value is num
+        ? value.toDouble()
+        : double.tryParse(value?.toString() ?? '');
+    if (parsed == null || parsed.isNaN || parsed.isInfinite) return null;
+    final ratio = parsed > 1 ? parsed / 100 : parsed;
+    return ratio.clamp(0.0, 1.0).toDouble();
+  }
+}
+
+/// One item of the `getScores` response.
+class _ScoreEntry extends _JsonRow {
+  _ScoreEntry(super.json);
+
+  String? get type => string('type') ?? string('scoreType');
+
+  String? get state => string('state');
+
+  double? get scoreFraction => fraction('score');
+
+  Object? get scoreDateTime => raw('scoreDateTime') ?? raw('startDateTime');
+
+  List<_ScoreFactor> get factors {
+    final value = raw('factors');
+    if (value is! List) return const [];
+    return [
+      for (final item in value)
+        if (item is Map) _ScoreFactor(item),
+    ];
+  }
+}
+
+/// One item of a score's `factors` array.
+class _ScoreFactor extends _JsonRow {
+  _ScoreFactor(super.json);
+
+  String? get name => string('name') ?? string('factor');
+
+  String? get state => string('state');
+
+  String? get value => number('value');
+
+  String? get goal => number('goal');
+
+  String? get unit => string('unit');
+
+  double? get scoreFraction => fraction('score');
+}
+
+/// `mental_wellbeing` -> `Mental wellbeing`.
+String _prettyLabel(String name) {
+  final words = name.replaceAll('_', ' ').trim();
+  if (words.isEmpty) return name;
+  return words[0].toUpperCase() + words.substring(1);
+}
+
+String _percentLabel(double fraction) => '${(fraction * 100).round()}%';
+
+/// Semantic colour for a score/factor state string.
+Color _stateColor(ThemeData theme, String? state) {
+  switch (state?.trim().toLowerCase()) {
+    case 'high':
+    case 'good':
+    case 'optimal':
+      return Colors.green.shade700;
+    case 'medium':
+    case 'ok':
+    case 'moderate':
+    case 'average':
+      return Colors.orange.shade800;
+    case 'low':
+    case 'poor':
+    case 'minimal':
+      return Colors.red.shade700;
+    default:
+      return theme.colorScheme.onSurfaceVariant;
+  }
+}
+
+String _formatNumber(num value) {
+  if (value.isNaN || value.isInfinite) return value.toString();
+  if (value is int || value == value.roundToDouble()) {
+    return value.toInt().toString();
+  }
+  return value.toStringAsFixed(2);
+}
+
+/// Formats an ISO 8601 string or epoch milliseconds, falling back to the raw
+/// value when it is neither.
+String? _formatDateTime(DateFormat format, Object? raw) {
+  if (raw == null) return null;
+  if (raw is num) {
+    return format.format(
+      DateTime.fromMillisecondsSinceEpoch(raw.toInt(), isUtc: true).toLocal(),
+    );
+  }
+  final text = raw.toString().trim();
+  if (text.isEmpty) return null;
+  final parsed = DateTime.tryParse(text);
+  return parsed == null ? text : format.format(parsed.toLocal());
 }

--- a/example/lib/Views/SensorDiagnosticsView.dart
+++ b/example/lib/Views/SensorDiagnosticsView.dart
@@ -1,0 +1,718 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:sahha_flutter/sahha_flutter.dart';
+import 'package:sahha_flutter_example/widgets/multi_select_sheet.dart';
+import 'package:sahha_flutter_example/widgets/response_sheet.dart';
+import 'package:sahha_flutter_example/widgets/sensor_groups.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// One-stop screen for answering "why is my data not flowing?" on a device:
+/// authentication + platform + combined sensor status, a per-sensor status
+/// matrix, the three side-effecting SDK calls, and an on-screen activity log
+/// so the maintainer does not need the Xcode/adb console.
+class SensorDiagnosticsView extends StatefulWidget {
+  const SensorDiagnosticsView({super.key});
+
+  @override
+  State<SensorDiagnosticsView> createState() => SensorDiagnosticsState();
+}
+
+class SensorDiagnosticsState extends State<SensorDiagnosticsView> {
+  /// Sensors under test, persisted as enum-name strings.
+  static const String _prefsKey = 'diagnostics.sensors';
+
+  /// A pragmatic default: the sensors most demos actually depend on.
+  static const List<SahhaSensor> _defaultSensors = <SahhaSensor>[
+    SahhaSensor.sleep,
+    SahhaSensor.steps,
+    SahhaSensor.heart_rate,
+    SahhaSensor.resting_heart_rate,
+    SahhaSensor.heart_rate_variability_sdnn,
+    SahhaSensor.active_energy_burned,
+    SahhaSensor.floors_climbed,
+    SahhaSensor.exercise,
+  ];
+
+  static const int _maxLogEntries = 50;
+  static final DateFormat _logTimeFormat = DateFormat('HH:mm:ss');
+
+  List<SahhaSensor> _sensors = List<SahhaSensor>.of(_defaultSensors);
+
+  bool _authBusy = false;
+  bool? _isAuthenticated;
+
+  bool _combinedBusy = false;
+  SahhaSensorStatus? _combinedStatus;
+
+  final Map<SahhaSensor, SahhaSensorStatus> _statuses = {};
+  final Set<SahhaSensor> _querying = {};
+
+  bool _enableBusy = false;
+  SahhaSensorStatus? _enableResult;
+  String? _postResult;
+  String? _settingsResult;
+
+  final List<_LogEntry> _logEntries = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _restoreSensors().then((_) => _refreshAll());
+  }
+
+  // ---------------------------------------------------------------- logging
+
+  void _appendLog(String message, {bool isError = false}) {
+    final entry = _LogEntry(
+      _logTimeFormat.format(DateTime.now()),
+      message,
+      isError,
+    );
+    if (!mounted) return;
+    setState(() {
+      _logEntries.insert(0, entry);
+      if (_logEntries.length > _maxLogEntries) {
+        _logEntries.removeRange(_maxLogEntries, _logEntries.length);
+      }
+    });
+  }
+
+  /// Hard failures get a log line, a device-log line and a response sheet.
+  void _reportError(String action, Object error, {String? subtitle}) {
+    debugPrint('Diagnostics: $action failed -> $error');
+    _appendLog('$action FAILED: $error', isError: true);
+    if (!mounted) return;
+    unawaited(
+      showResponseSheet(
+        context,
+        title: '$action failed',
+        subtitle: subtitle,
+        body: error.toString(),
+        isError: true,
+      ),
+    );
+  }
+
+  // ------------------------------------------------------------ persistence
+
+  Future<void> _restoreSensors() async {
+    List<String>? saved;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      saved = prefs.getStringList(_prefsKey);
+    } catch (error) {
+      debugPrint('Diagnostics: reading $_prefsKey failed -> $error');
+      _appendLog('Could not read saved sensors: $error', isError: true);
+      return;
+    }
+    if (saved == null) return;
+
+    final byName = {
+      for (final sensor in SahhaSensor.values) sensor.name: sensor,
+    };
+    final restored = <SahhaSensor>[];
+    final unknown = <String>[];
+    for (final name in saved) {
+      final sensor = byName[name];
+      if (sensor == null) {
+        unknown.add(name);
+      } else if (!restored.contains(sensor)) {
+        restored.add(sensor);
+      }
+    }
+    if (unknown.isNotEmpty) {
+      _appendLog('Ignored unknown saved sensors: ${unknown.join(', ')}');
+    }
+    if (!mounted) return;
+    setState(() => _sensors = restored);
+  }
+
+  Future<void> _persistSensors() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList(_prefsKey, [
+        for (final sensor in _sensors) sensor.name,
+      ]);
+    } catch (error) {
+      debugPrint('Diagnostics: writing $_prefsKey failed -> $error');
+      _appendLog('Could not save sensor selection: $error', isError: true);
+    }
+  }
+
+  // --------------------------------------------------------------- checking
+
+  Future<void> _refreshAll() async {
+    _appendLog('Running all diagnostics checks');
+    await Future.wait([
+      _refreshAuthentication(),
+      _refreshCombinedStatus(),
+      _refreshMatrix(),
+    ]);
+  }
+
+  Future<void> _refreshAuthentication() async {
+    if (!mounted) return;
+    setState(() => _authBusy = true);
+    try {
+      final value = await SahhaFlutter.isAuthenticated();
+      debugPrint('Diagnostics: isAuthenticated() -> $value');
+      if (!mounted) return;
+      setState(() {
+        _isAuthenticated = value;
+        _authBusy = false;
+      });
+      _appendLog('isAuthenticated() -> $value');
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _isAuthenticated = null;
+          _authBusy = false;
+        });
+      }
+      _reportError('isAuthenticated()', error);
+    }
+  }
+
+  Future<void> _refreshCombinedStatus() async {
+    if (!mounted) return;
+    final sensors = List<SahhaSensor>.of(_sensors);
+    if (sensors.isEmpty) {
+      setState(() {
+        _combinedStatus = null;
+        _combinedBusy = false;
+      });
+      return;
+    }
+    setState(() => _combinedBusy = true);
+    try {
+      final status = await SahhaFlutter.getSensorStatus(sensors);
+      debugPrint(
+        'Diagnostics: getSensorStatus(${sensors.length} sensors) -> ${status.name}',
+      );
+      if (!mounted) return;
+      setState(() {
+        _combinedStatus = status;
+        _combinedBusy = false;
+      });
+      _appendLog(
+        'getSensorStatus(${sensors.length} sensors) -> ${status.name}',
+      );
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _combinedStatus = null;
+          _combinedBusy = false;
+        });
+      }
+      _reportError('getSensorStatus(${sensors.length} sensors)', error);
+    }
+  }
+
+  /// getSensorStatus returns ONE combined status for a set, so the matrix is
+  /// built from one single-sensor call per row.
+  Future<Object?> _querySensorStatus(SahhaSensor sensor) async {
+    if (!mounted) return null;
+    setState(() => _querying.add(sensor));
+    try {
+      final status = await SahhaFlutter.getSensorStatus([sensor]);
+      debugPrint(
+        'Diagnostics: getSensorStatus([${sensor.name}]) -> ${status.name}',
+      );
+      if (!mounted) return null;
+      setState(() {
+        _statuses[sensor] = status;
+        _querying.remove(sensor);
+      });
+      _appendLog('${sensor.name} -> ${status.name}');
+      return null;
+    } catch (error) {
+      debugPrint('Diagnostics: getSensorStatus([${sensor.name}]) -> $error');
+      if (mounted) {
+        setState(() {
+          _statuses.remove(sensor);
+          _querying.remove(sensor);
+        });
+      }
+      _appendLog('${sensor.name} FAILED: $error', isError: true);
+      return error;
+    }
+  }
+
+  Future<void> _refreshMatrix() async {
+    if (!mounted) return;
+    final sensors = List<SahhaSensor>.of(_sensors);
+    if (sensors.isEmpty) {
+      setState(_statuses.clear);
+      return;
+    }
+    final results = await Future.wait(sensors.map(_querySensorStatus));
+    final failures = results.whereType<Object>().toList();
+    if (failures.isEmpty) return;
+    if (!mounted) return;
+    // One sheet for the batch, not one per failing sensor.
+    unawaited(
+      showResponseSheet(
+        context,
+        title: 'getSensorStatus failed',
+        subtitle: '${failures.length} of ${sensors.length} sensors',
+        body: failures.map((error) => error.toString()).join('\n\n'),
+        isError: true,
+      ),
+    );
+  }
+
+  Future<void> _refreshSensor(SahhaSensor sensor) async {
+    final error = await _querySensorStatus(sensor);
+    if (error == null) return;
+    if (!mounted) return;
+    unawaited(
+      showResponseSheet(
+        context,
+        title: 'getSensorStatus failed',
+        subtitle: sensor.name,
+        body: error.toString(),
+        isError: true,
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------- actions
+
+  Future<void> _editSensors() async {
+    final selection = await showMultiSelectSheet<SahhaSensor>(
+      context: context,
+      title: 'Sensors under test',
+      options: sensorsGroupedInEnumOrder(),
+      initialSelection: _sensors.toSet(),
+      labelOf: (sensor) => sensor.name,
+      groupOf: sensorGroupOf,
+    );
+    if (selection == null || !mounted) return;
+    // Keep groups contiguous by reusing the grouped enum order.
+    final ordered = [
+      for (final sensor in sensorsGroupedInEnumOrder())
+        if (selection.contains(sensor)) sensor,
+    ];
+    setState(() {
+      _sensors = ordered;
+      _statuses.removeWhere((sensor, _) => !selection.contains(sensor));
+    });
+    _appendLog('Sensors under test: ${ordered.length} selected');
+    await _persistSensors();
+    await Future.wait([_refreshCombinedStatus(), _refreshMatrix()]);
+  }
+
+  Future<void> _enableSensors() async {
+    if (!mounted) return;
+    final sensors = List<SahhaSensor>.of(_sensors);
+    if (sensors.isEmpty) {
+      _appendLog('enableSensors() skipped — no sensors selected');
+      return;
+    }
+    setState(() => _enableBusy = true);
+    _appendLog('enableSensors(${sensors.length} sensors) requested');
+    try {
+      final status = await SahhaFlutter.enableSensors(sensors);
+      debugPrint(
+        'Diagnostics: enableSensors(${sensors.length} sensors) -> ${status.name}',
+      );
+      if (!mounted) return;
+      setState(() {
+        _enableBusy = false;
+        _enableResult = status;
+      });
+      _appendLog('enableSensors() -> ${status.name}');
+      await Future.wait([_refreshCombinedStatus(), _refreshMatrix()]);
+    } catch (error) {
+      if (mounted) setState(() => _enableBusy = false);
+      _reportError('enableSensors(${sensors.length} sensors)', error);
+    }
+  }
+
+  void _postSensorData() {
+    SahhaFlutter.postSensorData();
+    debugPrint('Diagnostics: postSensorData() called — fire and forget');
+    setState(
+      () => _postResult = 'Requested ${_logTimeFormat.format(DateTime.now())}',
+    );
+    _appendLog(
+      'postSensorData() called — fire-and-forget (void, no result callback)',
+    );
+  }
+
+  void _openAppSettings() {
+    SahhaFlutter.openAppSettings();
+    debugPrint('Diagnostics: openAppSettings() called');
+    setState(
+      () => _settingsResult = 'Opened ${_logTimeFormat.format(DateTime.now())}',
+    );
+    _appendLog('openAppSettings() called — check the OS permission screen');
+  }
+
+  Future<void> _openAuthentication() async {
+    await Navigator.of(context).pushNamed('/authentication');
+    if (!mounted) return;
+    await _refreshAuthentication();
+  }
+
+  // ------------------------------------------------------------------- view
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sensor Diagnostics')),
+      body: RefreshIndicator(
+        onRefresh: _refreshAll,
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+          children: [
+            Text(
+              'Pull down to re-run every check on this device.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 12),
+            _buildSummaryCard(theme),
+            _sectionHeader(
+              theme,
+              'Sensor status',
+              actions: [
+                TextButton.icon(
+                  onPressed: _editSensors,
+                  icon: const Icon(Icons.tune, size: 18),
+                  label: const Text('Edit sensors'),
+                ),
+                IconButton(
+                  tooltip: 'Refresh all',
+                  onPressed: _refreshMatrix,
+                  icon: const Icon(Icons.refresh),
+                ),
+              ],
+            ),
+            _buildMatrixCard(theme),
+            _sectionHeader(theme, 'Actions'),
+            _buildActionsCard(theme),
+            _sectionHeader(
+              theme,
+              'Activity log',
+              actions: [
+                Text(
+                  '${_logEntries.length}/$_maxLogEntries',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Clear log',
+                  onPressed: _logEntries.isEmpty
+                      ? null
+                      : () => setState(_logEntries.clear),
+                  icon: const Icon(Icons.delete_outline),
+                ),
+              ],
+            ),
+            _buildLogCard(theme),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _sectionHeader(
+    ThemeData theme,
+    String title, {
+    List<Widget> actions = const [],
+  }) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, 24, actions.isEmpty ? 4 : 0, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              title,
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.primary,
+              ),
+            ),
+          ),
+          ...actions,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummaryCard(ThemeData theme) {
+    final authenticated = _isAuthenticated;
+    final String authTitle;
+    final String authSubtitle;
+    if (_authBusy) {
+      authTitle = 'Checking authentication…';
+      authSubtitle = 'isAuthenticated()';
+    } else if (authenticated == true) {
+      authTitle = 'Authenticated';
+      authSubtitle = 'A profile is signed in, so data can be posted.';
+    } else if (authenticated == false) {
+      authTitle = 'Not authenticated';
+      authSubtitle = 'No data will flow. Tap to authenticate a profile.';
+    } else {
+      authTitle = 'Authentication unknown';
+      authSubtitle = 'isAuthenticated() failed. Tap to open Authentication.';
+    }
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Column(
+        children: [
+          ListTile(
+            leading: _authBusy
+                ? const _RowSpinner()
+                : Icon(
+                    authenticated == true
+                        ? Icons.check_circle
+                        : Icons.warning_amber_rounded,
+                    color: authenticated == true
+                        ? Colors.green.shade600
+                        : Colors.orange.shade700,
+                  ),
+            title: Text(authTitle),
+            subtitle: Text(authSubtitle, style: theme.textTheme.bodySmall),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: _openAuthentication,
+          ),
+          const Divider(height: 1, indent: 16, endIndent: 16),
+          ListTile(
+            leading: Icon(
+              Platform.isIOS ? Icons.phone_iphone : Icons.phone_android,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            title: Text(Platform.operatingSystem),
+            subtitle: Text(
+              Platform.operatingSystemVersion,
+              style: theme.textTheme.bodySmall,
+            ),
+          ),
+          const Divider(height: 1, indent: 16, endIndent: 16),
+          ListTile(
+            leading: Icon(
+              Icons.sensors,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            title: const Text('Combined sensor status'),
+            subtitle: Text(
+              _sensors.isEmpty
+                  ? 'No sensors selected'
+                  : 'One getSensorStatus() call for all '
+                        '${_sensors.length} selected sensors',
+              style: theme.textTheme.bodySmall,
+            ),
+            trailing: _combinedBusy
+                ? const _RowSpinner()
+                : _statusChip(theme, _combinedStatus),
+            onTap: _refreshCombinedStatus,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMatrixCard(ThemeData theme) {
+    if (_sensors.isEmpty) {
+      return Card(
+        margin: EdgeInsets.zero,
+        child: ListTile(
+          leading: Icon(
+            Icons.playlist_add,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          title: const Text('No sensors under test'),
+          subtitle: Text(
+            'Tap "Edit sensors" to pick the sensors to check.',
+            style: theme.textTheme.bodySmall,
+          ),
+          onTap: _editSensors,
+        ),
+      );
+    }
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Column(
+        children: [
+          for (final sensor in _sensors) ...[
+            if (sensor != _sensors.first)
+              const Divider(height: 1, indent: 16, endIndent: 16),
+            ListTile(
+              dense: true,
+              title: Text(sensor.name),
+              subtitle: Text(
+                sensorGroupOf(sensor),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              trailing: _querying.contains(sensor)
+                  ? const _RowSpinner()
+                  : _statusChip(theme, _statuses[sensor]),
+              onTap: () => _refreshSensor(sensor),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionsCard(ThemeData theme) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Column(
+        children: [
+          _actionTile(
+            theme,
+            icon: Icons.toggle_on_outlined,
+            title: 'Enable selected sensors',
+            description:
+                'enableSensors() prompts for permission, then re-checks status.',
+            busy: _enableBusy,
+            result: _enableResult == null
+                ? null
+                : _statusChip(theme, _enableResult),
+            onTap: _enableSensors,
+          ),
+          const Divider(height: 1, indent: 16, endIndent: 16),
+          _actionTile(
+            theme,
+            icon: Icons.cloud_upload_outlined,
+            title: 'Post sensor data',
+            description:
+                'postSensorData() is fire-and-forget — it returns no result.',
+            resultText: _postResult,
+            onTap: _postSensorData,
+          ),
+          const Divider(height: 1, indent: 16, endIndent: 16),
+          _actionTile(
+            theme,
+            icon: Icons.settings_outlined,
+            title: 'Open app settings',
+            description:
+                'openAppSettings() opens the OS permission screen for this app.',
+            resultText: _settingsResult,
+            onTap: _openAppSettings,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _actionTile(
+    ThemeData theme, {
+    required IconData icon,
+    required String title,
+    required String description,
+    required VoidCallback onTap,
+    bool busy = false,
+    Widget? result,
+    String? resultText,
+  }) {
+    final feedback =
+        result ??
+        (resultText == null
+            ? null
+            : Text(
+                resultText,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ));
+    return ListTile(
+      leading: Icon(icon, color: theme.colorScheme.primary),
+      title: Text(title),
+      subtitle: Text(description, style: theme.textTheme.bodySmall),
+      trailing: busy ? const _RowSpinner() : feedback,
+      onTap: busy ? null : onTap,
+    );
+  }
+
+  Widget _buildLogCard(ThemeData theme) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: _logEntries.isEmpty
+              ? [
+                  Text(
+                    'Nothing yet. Every action and result is logged here.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ]
+              : [
+                  for (final entry in _logEntries)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 2),
+                      child: Text(
+                        '${entry.time}  ${entry.message}',
+                        style: monoStyle(context, fontSize: 11).copyWith(
+                          color: entry.isError ? theme.colorScheme.error : null,
+                        ),
+                      ),
+                    ),
+                ],
+        ),
+      ),
+    );
+  }
+
+  Widget _statusChip(ThemeData theme, SahhaSensorStatus? status) {
+    final color = _statusColor(status);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        status?.name ?? 'not checked',
+        style: theme.textTheme.labelMedium?.copyWith(color: color),
+      ),
+    );
+  }
+
+  Color _statusColor(SahhaSensorStatus? status) => switch (status) {
+    SahhaSensorStatus.enabled => Colors.green.shade600,
+    SahhaSensorStatus.disabled => Colors.orange.shade700,
+    SahhaSensorStatus.unavailable => Colors.red.shade600,
+    SahhaSensorStatus.pending => Colors.grey.shade600,
+    null => Colors.grey.shade500,
+  };
+}
+
+/// Small trailing/leading spinner used for per-row and per-section loading.
+class _RowSpinner extends StatelessWidget {
+  const _RowSpinner();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      width: 18,
+      height: 18,
+      child: CircularProgressIndicator(strokeWidth: 2),
+    );
+  }
+}
+
+class _LogEntry {
+  const _LogEntry(this.time, this.message, this.isError);
+
+  final String time;
+  final String message;
+  final bool isError;
+}

--- a/example/lib/Views/SensorPermissionView.dart
+++ b/example/lib/Views/SensorPermissionView.dart
@@ -1,201 +1,757 @@
-import 'package:flutter/material.dart';
-import 'package:sahha_flutter/sahha_flutter.dart';
+import 'dart:async';
 
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:sahha_flutter/sahha_flutter.dart';
+import 'package:sahha_flutter_example/widgets/response_sheet.dart';
+import 'package:sahha_flutter_example/widgets/sensor_groups.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Exercises `getSensorStatus`, `enableSensors` and `openAppSettings` against
+/// an arbitrary set of sensors picked on screen.
+///
+/// Both SDK calls run on exactly the checked list, which subsumes the fixed
+/// "empty / some / all" buttons this screen used to carry: check nothing for
+/// the empty-list edge case, check everything for the whole enum, or check any
+/// subset in between. The selection is persisted so a device keeps whatever
+/// the last test was.
 class SensorPermissionView extends StatefulWidget {
-  const SensorPermissionView({Key? key}) : super(key: key);
+  const SensorPermissionView({super.key});
 
   @override
   State<SensorPermissionView> createState() => SensorPermissionState();
 }
 
 class SensorPermissionState extends State<SensorPermissionView> {
-  SahhaSensorStatus sensorStatus = SahhaSensorStatus.pending;
+  /// Checked sensors, persisted as enum-name strings.
+  static const String _prefsKey = 'permissions.sensors';
+
+  /// The pair the old "SOME" buttons hard-coded — now just a quick action.
+  static const List<SahhaSensor> _defaultSensors = <SahhaSensor>[
+    SahhaSensor.steps,
+    SahhaSensor.sleep,
+  ];
+
+  static const String _getStatusCall = 'getSensorStatus';
+  static const String _enableCall = 'enableSensors';
+
+  static const int _maxLogEntries = 30;
+  static final DateFormat _logTimeFormat = DateFormat('HH:mm:ss');
+
+  /// Sensor groups in `sensorsGroupedInEnumOrder()` order, built once.
+  static final List<_SensorGroup> _groups = _buildGroups();
+
+  /// Every sensor flattened back out of [_groups], so a list handed to the SDK
+  /// keeps each group contiguous.
+  static final List<SahhaSensor> _ordered = <SahhaSensor>[
+    for (final group in _groups) ...group.sensors,
+  ];
+
+  Set<SahhaSensor> _selected = _defaultSensors.toSet();
+
+  /// Status returned by the most recent successful call.
+  SahhaSensorStatus? _status;
+
+  /// True when the most recent call threw, so the hero stops claiming a status.
+  bool _lastCallFailed = false;
+
+  /// Hero caption: "getSensorStatus · 3 sensors · 10:32:05".
+  String? _caption;
+
+  /// Name of the SDK call in flight, or null when idle.
+  String? _busyCall;
+
+  String? _settingsResult;
+
+  final List<_LogEntry> _log = [];
 
   @override
   void initState() {
     super.initState();
-    onTapGetSome(context);
+    unawaited(_restoreThenCheck());
   }
 
-  onTapGetSome(BuildContext context) {
-    SahhaFlutter.getSensorStatus(
-            [SahhaSensor.steps, SahhaSensor.sleep])
-        .then((value) {
-      setState(() {
-        sensorStatus = value;
-      });
-      debugPrint('Get Some Sensors ' + sensorStatus.name);
-    }).catchError((error) {
-      debugPrint(error.toString());
-      showAlertDialog(context,"Error",error.toString());
+  static List<_SensorGroup> _buildGroups() {
+    final byGroup = <String, List<SahhaSensor>>{};
+    for (final sensor in sensorsGroupedInEnumOrder()) {
+      byGroup
+          .putIfAbsent(sensorGroupOf(sensor), () => <SahhaSensor>[])
+          .add(sensor);
+    }
+    return [
+      for (final entry in byGroup.entries) _SensorGroup(entry.key, entry.value),
+    ];
+  }
+
+  // ---------------------------------------------------------------- logging
+
+  void _appendLog(String message, {bool isError = false}) {
+    final entry = _LogEntry(
+      _logTimeFormat.format(DateTime.now()),
+      message,
+      isError,
+    );
+    if (!mounted) return;
+    setState(() {
+      _log.insert(0, entry);
+      if (_log.length > _maxLogEntries) {
+        _log.removeRange(_maxLogEntries, _log.length);
+      }
     });
   }
 
-  onTapGetEmpty(BuildContext context) {
-    SahhaFlutter.getSensorStatus([]).then((value) {
-      setState(() {
-        sensorStatus = value;
-      });
-      debugPrint('Get Empty Sensors ' + sensorStatus.name);
-    }).catchError((error) {
-      debugPrint(error.toString());
-      showAlertDialog(context,"Error",error.toString());
-    });
+  // ------------------------------------------------------------ persistence
+
+  Future<void> _restoreThenCheck() async {
+    await _restoreSelection();
+    if (!mounted) return;
+    await _run(_getStatusCall, SahhaFlutter.getSensorStatus);
   }
 
-  onTapEnableSome(BuildContext context) {
-    SahhaFlutter.enableSensors(
-            [SahhaSensor.steps, SahhaSensor.sleep])
-        .then((value) {
-      setState(() {
-        sensorStatus = value;
-      });
-      debugPrint('Enable Some Sensors ' + sensorStatus.name);
-    }).catchError((error) {
-      debugPrint(error.toString());
-      showAlertDialog(context,"Error",error.toString());
-    });
+  Future<void> _restoreSelection() async {
+    List<String>? saved;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      saved = prefs.getStringList(_prefsKey);
+    } catch (error) {
+      debugPrint('Permissions: reading $_prefsKey failed -> $error');
+      _appendLog('Could not read the saved selection: $error', isError: true);
+      return;
+    }
+    if (saved == null) {
+      _appendLog(
+        'No saved selection — using the default set '
+        '(${_defaultSensors.map((sensor) => sensor.name).join(' + ')})',
+      );
+      return;
+    }
+
+    final byName = {
+      for (final sensor in SahhaSensor.values) sensor.name: sensor,
+    };
+    final restored = <SahhaSensor>{};
+    final unknown = <String>[];
+    for (final name in saved) {
+      final sensor = byName[name];
+      if (sensor == null) {
+        unknown.add(name);
+      } else {
+        restored.add(sensor);
+      }
+    }
+    if (unknown.isNotEmpty) {
+      _appendLog('Ignored unknown saved sensors: ${unknown.join(', ')}');
+    }
+    if (!mounted) return;
+    setState(() => _selected = restored);
+    _appendLog('Restored a saved selection of ${_countLabel(restored.length)}');
   }
 
-  onTapEnableEmpty(BuildContext context) {
-    SahhaFlutter.enableSensors([]).then((value) {
-      setState(() {
-        sensorStatus = value;
-      });
-      debugPrint('Enable Empty Sensors ' + sensorStatus.name);
-    }).catchError((error) {
-      debugPrint(error.toString());
-      showAlertDialog(context,"Error",error.toString());
-    });
+  Future<void> _persistSelection() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList(_prefsKey, [
+        for (final sensor in _checkedList()) sensor.name,
+      ]);
+    } catch (error) {
+      debugPrint('Permissions: writing $_prefsKey failed -> $error');
+      _appendLog('Could not save the selection: $error', isError: true);
+    }
   }
 
-  onTapEnableAll(BuildContext context) {
-    SahhaFlutter.enableSensors(SahhaSensor.values).then((value) {
-      setState(() {
-        sensorStatus = value;
-      });
-      debugPrint('Enable All Sensors ' + sensorStatus.name);
-    }).catchError((error) {
-      debugPrint(error.toString());
-      showAlertDialog(context,"Error",error.toString());
-    });
+  // -------------------------------------------------------------- selection
+
+  /// The checked sensors in grouped-enum order — the exact list handed to the
+  /// SDK by both actions.
+  List<SahhaSensor> _checkedList() => [
+    for (final sensor in _ordered)
+      if (_selected.contains(sensor)) sensor,
+  ];
+
+  String _countLabel(int count) =>
+      count == 0 ? 'empty list' : '$count sensor${count == 1 ? '' : 's'}';
+
+  void _applySelection(Set<SahhaSensor> selection, String logMessage) {
+    setState(() => _selected = selection);
+    _appendLog(logMessage);
+    unawaited(_persistSelection());
   }
 
-  openAppSettings(BuildContext context) {
-    debugPrint('Open App Settings');
+  void _selectAll() => _applySelection(
+    SahhaSensor.values.toSet(),
+    'Selected all (${SahhaSensor.values.length})',
+  );
+
+  void _selectNone() => _applySelection(<SahhaSensor>{}, 'Selection cleared');
+
+  void _selectDefault() => _applySelection(
+    _defaultSensors.toSet(),
+    'Selected the default set '
+    '(${_defaultSensors.map((sensor) => sensor.name).join(' + ')})',
+  );
+
+  void _toggleSensor(SahhaSensor sensor, bool checked) {
+    setState(() {
+      if (checked) {
+        _selected.add(sensor);
+      } else {
+        _selected.remove(sensor);
+      }
+    });
+    unawaited(_persistSelection());
+  }
+
+  void _toggleGroup(_SensorGroup group) {
+    final selectWholeGroup = !group.sensors.every(_selected.contains);
+    setState(() {
+      if (selectWholeGroup) {
+        _selected.addAll(group.sensors);
+      } else {
+        _selected.removeAll(group.sensors);
+      }
+    });
+    _appendLog(
+      selectWholeGroup
+          ? 'Selected all of ${group.name} (${group.sensors.length})'
+          : 'Cleared ${group.name} (${group.sensors.length})',
+    );
+    unawaited(_persistSelection());
+  }
+
+  // ---------------------------------------------------------------- actions
+
+  void _getStatus() =>
+      unawaited(_run(_getStatusCall, SahhaFlutter.getSensorStatus));
+
+  void _enableSensors() =>
+      unawaited(_run(_enableCall, SahhaFlutter.enableSensors));
+
+  /// Runs [call] with the checked list. An empty list is deliberately allowed:
+  /// it is a supported edge case of both native bridges.
+  Future<void> _run(
+    String name,
+    Future<SahhaSensorStatus> Function(List<SahhaSensor>) call,
+  ) async {
+    if (_busyCall != null || !mounted) return;
+    final sensors = _checkedList();
+    final label = '$name · ${_countLabel(sensors.length)}';
+
+    setState(() {
+      _busyCall = name;
+      _caption = '$label · running…';
+    });
+    _appendLog('$label requested');
+
+    try {
+      final status = await call(sensors);
+      debugPrint(
+        'Permissions: $name(${sensors.length} sensors) -> '
+        '${status.name}',
+      );
+      if (!mounted) return;
+      setState(() {
+        _busyCall = null;
+        _status = status;
+        _lastCallFailed = false;
+        _caption = '$label · ${_logTimeFormat.format(DateTime.now())}';
+      });
+      _appendLog('$label -> ${status.name}');
+    } catch (error) {
+      debugPrint(
+        'Permissions: $name(${sensors.length} sensors) failed -> '
+        '$error',
+      );
+      if (mounted) {
+        setState(() {
+          _busyCall = null;
+          _status = null;
+          _lastCallFailed = true;
+          _caption =
+              '$label · failed · '
+              '${_logTimeFormat.format(DateTime.now())}';
+        });
+      }
+      _appendLog('$label FAILED: $error', isError: true);
+      if (!mounted) return;
+      unawaited(
+        showResponseSheet(
+          context,
+          title: '$name failed',
+          subtitle: _countLabel(sensors.length),
+          body: error.toString(),
+          isError: true,
+        ),
+      );
+    }
+  }
+
+  void _openAppSettings() {
     SahhaFlutter.openAppSettings();
+    debugPrint('Permissions: openAppSettings() called');
+    setState(
+      () => _settingsResult = 'Opened ${_logTimeFormat.format(DateTime.now())}',
+    );
+    _appendLog('openAppSettings() called — check the OS permission screen');
   }
-  showAlertDialog(BuildContext context, String title, String message) {
-    AlertDialog alert = AlertDialog(
-      title: Text(title),
-      content: SingleChildScrollView(child: Text(message)),
-      actions: <Widget>[
-        TextButton(
-          child: const Text('OK'),
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
+
+  // ------------------------------------------------------------------- view
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sensor Permissions')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+        children: [
+          _StatusHero(
+            status: _status,
+            caption: _caption,
+            failed: _lastCallFailed,
+          ),
+          _sectionHeader(theme, 'Sensors'),
+          _buildSelectionCard(theme),
+          const SizedBox(height: 12),
+          for (final group in _groups) _buildGroupTile(theme, group),
+          _sectionHeader(theme, 'Actions'),
+          _buildActions(theme),
+          _sectionHeader(theme, 'More'),
+          _buildMoreCard(theme),
+          _sectionHeader(
+            theme,
+            'Activity log',
+            actions: [
+              Text(
+                '${_log.length}/$_maxLogEntries',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              IconButton(
+                tooltip: 'Clear log',
+                onPressed: _log.isEmpty ? null : () => setState(_log.clear),
+                icon: const Icon(Icons.delete_outline),
+              ),
+            ],
+          ),
+          _buildLogCard(theme),
+        ],
+      ),
+    );
+  }
+
+  Widget _sectionHeader(
+    ThemeData theme,
+    String title, {
+    List<Widget> actions = const [],
+  }) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, 24, actions.isEmpty ? 4 : 0, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              title,
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.primary,
+                letterSpacing: 0.8,
+              ),
+            ),
+          ),
+          ...actions,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSelectionCard(ThemeData theme) {
+    final count = _selected.length;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.checklist_rounded,
+                  size: 20,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    '$count of ${SahhaSensor.values.length} sensors selected',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                ActionChip(
+                  avatar: const Icon(Icons.done_all, size: 18),
+                  label: const Text('All'),
+                  onPressed: _selectAll,
+                ),
+                ActionChip(
+                  avatar: const Icon(Icons.remove_done, size: 18),
+                  label: const Text('None'),
+                  onPressed: _selectNone,
+                ),
+                ActionChip(
+                  avatar: const Icon(Icons.star_outline, size: 18),
+                  label: const Text('Default'),
+                  onPressed: _selectDefault,
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              'Default = '
+              '${_defaultSensors.map((sensor) => sensor.name).join(' + ')}. '
+              'Expand a group below to check individual sensors.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGroupTile(ThemeData theme, _SensorGroup group) {
+    final selected = group.sensors.where(_selected.contains).length;
+    final total = group.sensors.length;
+    final bool? groupValue = selected == 0
+        ? false
+        : selected == total
+        ? true
+        : null;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: ExpansionTile(
+        key: PageStorageKey<String>('permissions.group.${group.name}'),
+        tilePadding: const EdgeInsets.fromLTRB(8, 0, 16, 0),
+        childrenPadding: const EdgeInsets.only(bottom: 8),
+        leading: Checkbox(
+          tristate: true,
+          value: groupValue,
+          onChanged: (_) => _toggleGroup(group),
+        ),
+        title: Text(
+          group.name,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        subtitle: Text(
+          '$selected/$total selected',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: selected == 0
+                ? theme.colorScheme.onSurfaceVariant
+                : theme.colorScheme.primary,
+          ),
+        ),
+        children: [
+          for (final sensor in group.sensors)
+            CheckboxListTile(
+              dense: true,
+              controlAffinity: ListTileControlAffinity.leading,
+              contentPadding: const EdgeInsets.only(left: 8, right: 16),
+              value: _selected.contains(sensor),
+              onChanged: (value) => _toggleSensor(sensor, value ?? false),
+              title: Text(sensor.name, style: monoStyle(context, fontSize: 12)),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActions(ThemeData theme) {
+    final busy = _busyCall != null;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FilledButton.tonal(
+          onPressed: busy ? null : _getStatus,
+          child: _buttonChild(
+            theme,
+            'GET STATUS',
+            Icons.fact_check_outlined,
+            _busyCall == _getStatusCall,
+          ),
+        ),
+        const SizedBox(height: 12),
+        FilledButton(
+          onPressed: busy ? null : _enableSensors,
+          child: _buttonChild(
+            theme,
+            'ENABLE SENSORS',
+            Icons.lock_open_outlined,
+            _busyCall == _enableCall,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Both calls run on exactly the checked list. ENABLE SENSORS is the '
+          'one that triggers the OS permission prompt. Calling with an empty '
+          'list is allowed — it exercises the SDK\'s default-set behaviour.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
         ),
       ],
     );
+  }
 
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return alert;
-      },
+  Widget _buttonChild(ThemeData theme, String label, IconData icon, bool busy) {
+    if (busy) {
+      return SizedBox(
+        height: 20,
+        width: 20,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          color: theme.colorScheme.onSurface,
+        ),
+      );
+    }
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [Icon(icon, size: 18), const SizedBox(width: 10), Text(label)],
     );
   }
+
+  Widget _buildMoreCard(ThemeData theme) {
+    return Card(
+      child: Column(
+        children: [
+          ListTile(
+            shape: const RoundedRectangleBorder(),
+            leading: Icon(
+              Icons.settings_outlined,
+              color: theme.colorScheme.primary,
+            ),
+            title: const Text('Open app settings'),
+            subtitle: Text(
+              'openAppSettings() opens the OS permission screen for this app.',
+              style: theme.textTheme.bodySmall,
+            ),
+            trailing: _settingsResult == null
+                ? null
+                : Text(
+                    _settingsResult!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+            onTap: _openAppSettings,
+          ),
+          const Divider(height: 1, indent: 16, endIndent: 16),
+          ListTile(
+            shape: const RoundedRectangleBorder(),
+            leading: Icon(
+              Icons.fact_check_outlined,
+              color: theme.colorScheme.primary,
+            ),
+            title: const Text('Per-sensor diagnostics'),
+            subtitle: Text(
+              'This screen returns one combined status. Diagnostics shows '
+              'each sensor\'s individual status.',
+              style: theme.textTheme.bodySmall,
+            ),
+            trailing: Icon(
+              Icons.chevron_right,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            onTap: () => Navigator.pushNamed(context, '/diagnostics'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLogCard(ThemeData theme) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: _log.isEmpty
+              ? [
+                  Text(
+                    'Nothing yet. Every call, result and selection change is '
+                    'logged here, newest first.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ]
+              : [
+                  for (final entry in _log)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 2),
+                      child: Text(
+                        '${entry.time}  ${entry.message}',
+                        style: monoStyle(context, fontSize: 11).copyWith(
+                          color: entry.isError ? theme.colorScheme.error : null,
+                        ),
+                      ),
+                    ),
+                ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A named bucket of sensors, from `sensorGroupOf`.
+class _SensorGroup {
+  const _SensorGroup(this.name, this.sensors);
+
+  final String name;
+  final List<SahhaSensor> sensors;
+}
+
+class _LogEntry {
+  const _LogEntry(this.time, this.message, this.isError);
+
+  final String time;
+  final String message;
+  final bool isError;
+}
+
+/// Hero card for the combined [SahhaSensorStatus] of the most recent call.
+class _StatusHero extends StatelessWidget {
+  const _StatusHero({
+    required this.status,
+    required this.caption,
+    required this.failed,
+  });
+
+  final SahhaSensorStatus? status;
+  final String? caption;
+  final bool failed;
+
+  Color get _color {
+    if (failed) return Colors.red.shade700;
+    return switch (status) {
+      SahhaSensorStatus.enabled => Colors.green.shade600,
+      SahhaSensorStatus.disabled => Colors.orange.shade800,
+      SahhaSensorStatus.unavailable => Colors.red.shade600,
+      SahhaSensorStatus.pending => Colors.grey.shade600,
+      null => Colors.grey.shade500,
+    };
+  }
+
+  IconData get _icon {
+    if (failed) return Icons.error_outline;
+    return switch (status) {
+      SahhaSensorStatus.enabled => Icons.sensors,
+      SahhaSensorStatus.disabled => Icons.sensors_off,
+      SahhaSensorStatus.unavailable => Icons.do_not_disturb_on_outlined,
+      SahhaSensorStatus.pending => Icons.hourglass_empty,
+      null => Icons.help_outline,
+    };
+  }
+
+  String get _label {
+    if (failed) return 'call failed';
+    return status?.name ?? 'not checked yet';
+  }
+
+  String get _description {
+    if (failed) return 'The call threw — see the log entry for the error.';
+    return switch (status) {
+      SahhaSensorStatus.enabled =>
+        'Collection is active for every sensor in the list.',
+      SahhaSensorStatus.disabled =>
+        'The user declined, or turned the requested sensors off.',
+      SahhaSensorStatus.unavailable =>
+        'Health data is not available on this device.',
+      SahhaSensorStatus.pending =>
+        'The user has not been asked for these sensors yet.',
+      null => 'Run GET STATUS or ENABLE SENSORS on the checked list.',
+    };
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Sensor Permissions'),
+    final theme = Theme.of(context);
+    final color = _color;
+
+    return Card(
+      color: color.withValues(alpha: 0.10),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: color.withValues(alpha: 0.45)),
       ),
-      body: ListView(padding: const EdgeInsets.all(40), children: <Widget>[
-        const Spacer(),
-        const Icon(
-          Icons.sensors,
-          size: 64,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(_icon, size: 40, color: color),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Combined sensor status',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 6,
+                    ),
+                    decoration: BoxDecoration(
+                      color: color.withValues(alpha: 0.16),
+                      borderRadius: BorderRadius.circular(999),
+                      border: Border.all(color: color.withValues(alpha: 0.5)),
+                    ),
+                    child: Text(
+                      _label,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: color,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    caption ?? 'No call made yet',
+                    style: monoStyle(
+                      context,
+                      fontSize: 11,
+                    ).copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    _description,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
-        const SizedBox(height: 20),
-        const Text('Sensor Status',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-        const SizedBox(height: 20),
-        Text(sensorStatus.name, style: const TextStyle(fontSize: 18)),
-        const SizedBox(height: 20),
-        ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            minimumSize: const Size.fromHeight(40),
-            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-            textStyle: const TextStyle(fontSize: 16),
-          ),
-          onPressed: () {
-            onTapGetEmpty(context);
-          },
-          child: const Text('GET EMPTY'),
-        ),
-        const SizedBox(height: 20),
-        ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            minimumSize: const Size.fromHeight(40),
-            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-            textStyle: const TextStyle(fontSize: 16),
-          ),
-          onPressed: () {
-            onTapGetSome(context);
-          },
-          child: const Text('GET SOME'),
-        ),
-        const SizedBox(height: 20),
-        ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            minimumSize: const Size.fromHeight(40),
-            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-            textStyle: const TextStyle(fontSize: 16),
-          ),
-          onPressed: () {
-            onTapEnableEmpty(context);
-          },
-          child: const Text('ENABLE EMPTY'),
-        ),
-        const SizedBox(height: 20),
-        ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            minimumSize: const Size.fromHeight(40),
-            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-            textStyle: const TextStyle(fontSize: 16),
-          ),
-          onPressed: () {
-            onTapEnableSome(context);
-          },
-          child: const Text('ENABLE SOME'),
-        ),
-        const SizedBox(height: 20),
-        ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            minimumSize: const Size.fromHeight(40),
-            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-            textStyle: const TextStyle(fontSize: 16),
-          ),
-          onPressed: () {
-            onTapEnableAll(context);
-          },
-          child: const Text('ENABLE ALL'),
-        ),
-        const SizedBox(height: 20),
-        ElevatedButton(
-          style: ElevatedButton.styleFrom(
-            minimumSize: const Size.fromHeight(40),
-            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-            textStyle: const TextStyle(fontSize: 16),
-          ),
-          onPressed: () {
-            openAppSettings(context);
-          },
-          child: const Text('OPEN APP SETTINGS'),
-        ),
-      ]),
+      ),
     );
   }
 }

--- a/example/lib/Views/StatsView.dart
+++ b/example/lib/Views/StatsView.dart
@@ -22,6 +22,8 @@ class StatsState extends State<StatsView> {
   }
 
   onTapGetStats(BuildContext context) {
+    // The demo intentionally shows the deprecated APIs alongside getBiomarkers.
+    // ignore: deprecated_member_use
     SahhaFlutter.getStats(
             sensor: SahhaSensor.values
                 .firstWhere((element) => element.name == sensor),

--- a/example/lib/Views/StatsView.dart
+++ b/example/lib/Views/StatsView.dart
@@ -1,120 +1,657 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:sahha_flutter/sahha_flutter.dart';
-import 'package:selectpicker/models/select_picker_item.dart';
-import 'package:selectpicker/selectpicker.dart';
-import 'package:selectpicker/styles/input_style.dart';
+import 'package:sahha_flutter_example/widgets/date_range_selector.dart';
+import 'package:sahha_flutter_example/widgets/response_sheet.dart';
+import 'package:sahha_flutter_example/widgets/sensor_groups.dart';
+import 'package:sahha_flutter_example/widgets/sensor_picker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+final DateFormat _dayFormat = DateFormat('EEE d MMM');
+final DateFormat _timeFormat = DateFormat('HH:mm');
+final DateFormat _dayTimeFormat = DateFormat('d MMM HH:mm');
+final NumberFormat _numberFormat = NumberFormat.decimalPattern();
+
+/// Test harness for the deprecated `getStats` API.
+///
+/// Kept so the aggregated on-device stats can be regression tested against the
+/// server-processed values returned by `getBiomarkers`.
 class StatsView extends StatefulWidget {
-  const StatsView({Key? key}) : super(key: key);
+  const StatsView({super.key});
 
   @override
   StatsState createState() => StatsState();
 }
 
 class StatsState extends State<StatsView> {
-  String sensor = '';
+  static const String _sensorPrefsKey = 'stats.sensor';
+
+  SahhaSensor? _sensor = SahhaSensor.steps;
+  late DateTime _start;
+  late DateTime _end;
+  bool _isLoading = false;
+  String? _raw;
+  String? _error;
+  List<_Stat>? _stats;
 
   @override
   void initState() {
     super.initState();
+
+    final now = DateTime.now();
+    _end = now;
+    _start = now.subtract(const Duration(days: 7));
+
+    _restoreSensor();
   }
 
-  onTapGetStats(BuildContext context) {
-    // The demo intentionally shows the deprecated APIs alongside getBiomarkers.
-    // ignore: deprecated_member_use
-    SahhaFlutter.getStats(
-          sensor: SahhaSensor.values.firstWhere(
-            (element) => element.name == sensor,
-          ),
-          startDateTime: DateTime.timestamp().subtract(const Duration(days: 7)),
-          endDateTime: DateTime.timestamp(),
-        )
-        .then((value) {
-          List<dynamic> data = jsonDecode(value);
-          debugPrint(data.firstOrNull?.toString());
-          const encoder = JsonEncoder.withIndent('      ');
-          final prettyJson = encoder.convert(data);
-          showAlertDialog(context, "STATS", prettyJson);
-        })
-        .catchError((error, stackTrace) {
-          showAlertDialog(context, "Error", error.toString());
-          return null;
-        });
+  Future<void> _restoreSensor() async {
+    final prefs = await SharedPreferences.getInstance();
+    final name = prefs.getString(_sensorPrefsKey);
+    if (name == null) return;
+    // Tolerate sensors that were removed or renamed since the value was saved.
+    final restored = _sensorNamed(name);
+    if (restored == null || !mounted) return;
+    setState(() => _sensor = restored);
   }
 
-  showAlertDialog(BuildContext context, String title, String message) {
-    AlertDialog alert = AlertDialog(
-      title: Text(title),
-      content: SingleChildScrollView(child: Text(message)),
-      actions: <Widget>[
-        TextButton(
-          child: const Text('OK'),
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-        ),
-      ],
-    );
+  Future<void> _saveSensor(SahhaSensor sensor) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_sensorPrefsKey, sensor.name);
+  }
 
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return alert;
-      },
+  SahhaSensor? _sensorNamed(String name) {
+    for (final sensor in SahhaSensor.values) {
+      if (sensor.name == name) return sensor;
+    }
+    return null;
+  }
+
+  Future<void> _pickSensor() async {
+    final picked = await showSensorPicker(context, selected: _sensor);
+    if (picked == null || !mounted) return;
+    setState(() => _sensor = picked);
+    await _saveSensor(picked);
+  }
+
+  Future<void> _getStats() async {
+    final sensor = _sensor;
+    if (sensor == null || _isLoading) return;
+
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    try {
+      // The demo intentionally exercises the deprecated APIs alongside
+      // getBiomarkers.
+      // ignore: deprecated_member_use
+      final raw = await SahhaFlutter.getStats(
+        sensor: sensor,
+        startDateTime: _start,
+        endDateTime: _end,
+      );
+      debugPrint(raw);
+      final stats = _parseStats(raw);
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _raw = raw;
+        _stats = stats;
+      });
+    } catch (error) {
+      debugPrint(error.toString());
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _raw = null;
+        _stats = null;
+        _error = error.toString();
+      });
+      showResponseSheet(
+        context,
+        title: 'GET STATS',
+        body: error.toString(),
+        subtitle: sensor.name,
+        isError: true,
+      );
+    }
+  }
+
+  void _showRawJson() {
+    final raw = _raw;
+    if (raw == null) return;
+    final count = _stats?.length ?? 0;
+    showResponseSheet(
+      context,
+      title: 'GET STATS',
+      body: tryPrettyJson(raw),
+      subtitle: '$count ${count == 1 ? 'entry' : 'entries'}',
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sensor = _sensor;
+
     return Scaffold(
       appBar: AppBar(title: const Text('Stats')),
-      body: Padding(
-        padding: const EdgeInsets.all(40),
-        child: Center(
-          child: Column(
-            children: <Widget>[
-              const Spacer(),
-              const Icon(Icons.pie_chart, size: 64),
-              const SizedBox(height: 20),
-              SelectPicker(
-                hint: sensor.isEmpty ? "SENSOR" : sensor,
-                list: [
-                  for (var sensor in SahhaSensor.values)
-                    SelectPickerItem(sensor.name, sensor.name, null),
-                ],
-                selectFirst: false,
-                showId: false,
-                onSelect: (value) {
-                  setState(() {
-                    sensor = value.title;
-                    debugPrint(sensor);
-                  });
-                },
-                selectPickerInputStyle: SelectPickerInputStyle(),
-                initialItem: sensor,
-              ),
-              const SizedBox(height: 40),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size.fromHeight(40),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 40,
-                    vertical: 20,
-                  ),
-                  textStyle: const TextStyle(fontSize: 16),
-                ),
-                onPressed: () {
-                  onTapGetStats(context);
-                },
-                child: const Text('GET STATS'),
-              ),
-              const SizedBox(height: 40),
-            ],
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+        children: [
+          const _DeprecationCallout(),
+          const SizedBox(height: 20),
+          const _SectionHeader('Query'),
+          const SizedBox(height: 12),
+          _SensorField(sensor: sensor, onTap: _isLoading ? null : _pickSensor),
+          const SizedBox(height: 12),
+          DateRangeSelector(
+            start: _start,
+            end: _end,
+            onChanged: (start, end) => setState(() {
+              _start = start;
+              _end = end;
+            }),
           ),
-        ),
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: _isLoading || sensor == null ? null : _getStats,
+              child: _isLoading
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('GET STATS'),
+            ),
+          ),
+          const SizedBox(height: 24),
+          ..._results(theme),
+        ],
       ),
     );
   }
+
+  List<Widget> _results(ThemeData theme) {
+    final error = _error;
+    if (error != null) {
+      return [
+        _InfoCard(
+          icon: Icons.error_outline,
+          color: theme.colorScheme.error,
+          title: 'GET STATS failed',
+          message: error,
+          action: TextButton(
+            onPressed: () => showResponseSheet(
+              context,
+              title: 'GET STATS',
+              body: error,
+              subtitle: _sensor?.name,
+              isError: true,
+            ),
+            child: const Text('Details'),
+          ),
+        ),
+      ];
+    }
+
+    final stats = _stats;
+    if (stats == null || _raw == null) return const [];
+
+    return [
+      Row(
+        children: [
+          Expanded(child: _resultsHeader(theme, stats)),
+          TextButton(onPressed: _showRawJson, child: const Text('Raw JSON')),
+        ],
+      ),
+      if (stats.isEmpty)
+        _InfoCard(
+          icon: Icons.inbox_outlined,
+          color: theme.colorScheme.onSurfaceVariant,
+          title: 'No stats returned',
+          message:
+              'Nothing was recorded for ${_sensor?.name ?? 'this sensor'} in '
+              'this date range. Check the sensor is enabled in Permissions and '
+              'that the device has data for the period.',
+        )
+      else ...[
+        const Divider(height: 1),
+        for (final stat in stats) ...[
+          _StatRow(stat: stat),
+          const Divider(height: 1),
+        ],
+      ],
+    ];
+  }
+
+  Widget _resultsHeader(ThemeData theme, List<_Stat> stats) {
+    final values = [
+      for (final stat in stats)
+        if (stat.value != null) stat.value!,
+    ];
+    final details = <String>[];
+    final types = {
+      for (final stat in stats)
+        if (stat.type != null) stat.type!,
+    };
+    if (types.isNotEmpty && types.length <= 3) {
+      details.add(types.join(', '));
+    }
+    if (values.isNotEmpty) {
+      final sum = values.fold<double>(0, (total, value) => total + value);
+      details.add(
+        'sum ${_numberFormat.format(sum)} · '
+        'avg ${_numberFormat.format(sum / values.length)}',
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '${stats.length} ${stats.length == 1 ? 'stat' : 'stats'}',
+          style: theme.textTheme.labelLarge?.copyWith(
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        if (details.isNotEmpty)
+          Text(
+            details.join(' · '),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// A single `getStats` entry, parsed defensively: field names and value types
+/// differ slightly between the iOS and Android bridges.
+class _Stat {
+  _Stat({
+    required this.type,
+    required this.value,
+    required this.valueText,
+    required this.unit,
+    required this.start,
+    required this.end,
+    required this.rawStart,
+    required this.sources,
+  });
+
+  final String? type;
+  final double? value;
+  final String? valueText;
+  final String? unit;
+  final DateTime? start;
+  final DateTime? end;
+  final String? rawStart;
+  final List<String> sources;
+
+  String get periodLabel {
+    final start = this.start;
+    if (start == null) return rawStart ?? 'Unknown period';
+    final end = this.end;
+    if (end == null) return _dayFormat.format(start);
+
+    final minutes = end.difference(start).inMinutes;
+    final sameDay =
+        start.year == end.year &&
+        start.month == end.month &&
+        start.day == end.day;
+    // Daily periodicity (or a zero-length period): the day alone is enough.
+    final coversDay = minutes >= 23 * 60 && minutes <= 25 * 60;
+    if (coversDay || minutes <= 0) return _dayFormat.format(start);
+    if (sameDay) {
+      return '${_dayFormat.format(start)} · '
+          '${_timeFormat.format(start)}–${_timeFormat.format(end)}';
+    }
+    return '${_dayTimeFormat.format(start)} → ${_dayTimeFormat.format(end)}';
+  }
+
+  String get valueLabel {
+    final value = this.value;
+    final text = value != null
+        ? _numberFormat.format(value)
+        : (valueText ?? '—');
+    final unit = this.unit;
+    return unit == null || unit.isEmpty ? text : '$text $unit';
+  }
+}
+
+List<_Stat> _parseStats(String raw) {
+  final stats = <_Stat>[];
+  for (final map in _decodeEntries(raw, const ['stats', 'data', 'items'])) {
+    final value = _pick(map, const ['value', 'count', 'total']);
+    final start = _asDateTime(
+      _pick(map, const ['startDateTime', 'startDate', 'start']),
+    );
+    stats.add(
+      _Stat(
+        type: _asText(_pick(map, const ['type', 'name', 'sensor', 'category'])),
+        value: _asDouble(value),
+        valueText: _asText(value),
+        unit: _asText(_pick(map, const ['unit', 'unitName'])),
+        start: start,
+        end: _asDateTime(_pick(map, const ['endDateTime', 'endDate', 'end'])),
+        rawStart: _asText(
+          _pick(map, const ['startDateTime', 'startDate', 'start']),
+        ),
+        sources: _asTextList(_pick(map, const ['sources', 'source'])),
+      ),
+    );
+  }
+  // Most recent period first.
+  stats.sort((a, b) {
+    final aStart = a.start;
+    final bStart = b.start;
+    if (aStart == null && bStart == null) return 0;
+    if (aStart == null) return 1;
+    if (bStart == null) return -1;
+    return bStart.compareTo(aStart);
+  });
+  return stats;
+}
+
+class _StatRow extends StatelessWidget {
+  const _StatRow({required this.stat});
+
+  final _Stat stat;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(stat.periodLabel, style: theme.textTheme.bodyMedium),
+                if (stat.sources.isNotEmpty)
+                  Text(
+                    stat.sources.join(', '),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Text(
+            stat.valueLabel,
+            textAlign: TextAlign.right,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      title,
+      style: theme.textTheme.labelLarge?.copyWith(
+        color: theme.colorScheme.primary,
+      ),
+    );
+  }
+}
+
+class _SensorField extends StatelessWidget {
+  const _SensorField({required this.sensor, required this.onTap});
+
+  final SahhaSensor? sensor;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sensor = this.sensor;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: InputDecorator(
+        decoration: const InputDecoration(
+          labelText: 'Sensor',
+          border: OutlineInputBorder(),
+          contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          suffixIcon: Icon(Icons.expand_more, size: 20),
+        ),
+        child: sensor == null
+            ? Text(
+                'Select a sensor',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              )
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(sensor.name, style: theme.textTheme.bodyMedium),
+                  Text(
+                    sensorGroupOf(sensor),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+class _DeprecationCallout extends StatelessWidget {
+  const _DeprecationCallout();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 12, 4),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.tertiaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.info_outline,
+            size: 20,
+            color: theme.colorScheme.onTertiaryContainer,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'getStats is deprecated',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: theme.colorScheme.onTertiaryContainer,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'New integrations should use getBiomarkers. This screen '
+                  'stays so the deprecated API can be regression tested.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onTertiaryContainer,
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: () =>
+                        Navigator.pushNamed(context, '/biomarkers'),
+                    child: const Text('Open Biomarkers'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoCard extends StatelessWidget {
+  const _InfoCard({
+    required this.icon,
+    required this.color,
+    required this.title,
+    required this.message,
+    this.action,
+  });
+
+  final IconData icon;
+  final Color color;
+  final String title;
+  final String message;
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.only(top: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 20, color: color),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: theme.textTheme.titleSmall),
+                const SizedBox(height: 4),
+                Text(
+                  message,
+                  maxLines: 6,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                if (action != null)
+                  Align(alignment: Alignment.centerLeft, child: action),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Decodes a bridge payload into a list of string-keyed maps, tolerating a
+/// single object, a wrapper object and malformed JSON.
+List<Map<String, dynamic>> _decodeEntries(
+  String raw,
+  List<String> wrapperKeys,
+) {
+  dynamic decoded;
+  try {
+    decoded = jsonDecode(raw);
+  } catch (_) {
+    return const [];
+  }
+  if (decoded is Map) {
+    for (final key in wrapperKeys) {
+      final wrapped = decoded[key];
+      if (wrapped is List) {
+        decoded = wrapped;
+        break;
+      }
+    }
+  }
+  if (decoded is Map) {
+    return [decoded.map((key, value) => MapEntry(key.toString(), value))];
+  }
+  if (decoded is! List) return const [];
+  return [
+    for (final entry in decoded)
+      if (entry is Map)
+        entry.map((key, value) => MapEntry(key.toString(), value)),
+  ];
+}
+
+dynamic _pick(Map<String, dynamic> map, List<String> keys) {
+  for (final key in keys) {
+    final value = map[key];
+    if (value != null) return value;
+  }
+  return null;
+}
+
+String? _asText(dynamic value) {
+  if (value == null || value is Iterable || value is Map) return null;
+  final text = value.toString().trim();
+  return text.isEmpty ? null : text;
+}
+
+double? _asDouble(dynamic value) {
+  if (value is num) return value.toDouble();
+  if (value is String) return double.tryParse(value.trim());
+  return null;
+}
+
+List<String> _asTextList(dynamic value) {
+  if (value is Iterable) {
+    return [
+      for (final entry in value)
+        if (_asText(entry) != null) _asText(entry)!,
+    ];
+  }
+  final text = _asText(value);
+  return text == null ? const [] : [text];
+}
+
+DateTime? _asDateTime(dynamic value) {
+  if (value is num) {
+    // Seconds or milliseconds since epoch, depending on the platform.
+    final millis = value > 100000000000
+        ? value.toInt()
+        : (value * 1000).toInt();
+    return DateTime.fromMillisecondsSinceEpoch(millis).toLocal();
+  }
+  if (value is! String) return null;
+  var text = value.trim();
+  if (text.isEmpty) return null;
+  // Android serialises ZonedDateTime with a trailing zone id, which
+  // DateTime.parse rejects: 2026-05-21T09:00+12:00[Pacific/Auckland]
+  final zoneIndex = text.indexOf('[');
+  if (zoneIndex > 0) text = text.substring(0, zoneIndex);
+  return DateTime.tryParse(text)?.toLocal();
 }

--- a/example/lib/Views/StatsView.dart
+++ b/example/lib/Views/StatsView.dart
@@ -25,21 +25,23 @@ class StatsState extends State<StatsView> {
     // The demo intentionally shows the deprecated APIs alongside getBiomarkers.
     // ignore: deprecated_member_use
     SahhaFlutter.getStats(
-            sensor: SahhaSensor.values
-                .firstWhere((element) => element.name == sensor),
-            startDateTime:
-                DateTime.timestamp().subtract(const Duration(days: 7)),
-            endDateTime: DateTime.timestamp())
+          sensor: SahhaSensor.values.firstWhere(
+            (element) => element.name == sensor,
+          ),
+          startDateTime: DateTime.timestamp().subtract(const Duration(days: 7)),
+          endDateTime: DateTime.timestamp(),
+        )
         .then((value) {
-      List<dynamic> data = jsonDecode(value);
-      debugPrint(data.firstOrNull?.toString());
-      const encoder = JsonEncoder.withIndent('      ');
-      final prettyJson = encoder.convert(data);
-      showAlertDialog(context, "STATS", prettyJson);
-    }).catchError((error, stackTrace) {
-      showAlertDialog(context, "Error", error.toString());
-      return null;
-    });
+          List<dynamic> data = jsonDecode(value);
+          debugPrint(data.firstOrNull?.toString());
+          const encoder = JsonEncoder.withIndent('      ');
+          final prettyJson = encoder.convert(data);
+          showAlertDialog(context, "STATS", prettyJson);
+        })
+        .catchError((error, stackTrace) {
+          showAlertDialog(context, "Error", error.toString());
+          return null;
+        });
   }
 
   showAlertDialog(BuildContext context, String title, String message) {
@@ -67,25 +69,20 @@ class StatsState extends State<StatsView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Stats'),
-      ),
+      appBar: AppBar(title: const Text('Stats')),
       body: Padding(
         padding: const EdgeInsets.all(40),
         child: Center(
           child: Column(
             children: <Widget>[
               const Spacer(),
-              const Icon(
-                Icons.pie_chart,
-                size: 64,
-              ),
+              const Icon(Icons.pie_chart, size: 64),
               const SizedBox(height: 20),
               SelectPicker(
                 hint: sensor.isEmpty ? "SENSOR" : sensor,
                 list: [
                   for (var sensor in SahhaSensor.values)
-                    SelectPickerItem(sensor.name, sensor.name, null)
+                    SelectPickerItem(sensor.name, sensor.name, null),
                 ],
                 selectFirst: false,
                 showId: false,
@@ -102,8 +99,10 @@ class StatsState extends State<StatsView> {
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   minimumSize: const Size.fromHeight(40),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 40, vertical: 20),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 40,
+                    vertical: 20,
+                  ),
                   textStyle: const TextStyle(fontSize: 16),
                 ),
                 onPressed: () {

--- a/example/lib/Views/WebView.dart
+++ b/example/lib/Views/WebView.dart
@@ -8,7 +8,7 @@ import 'package:webview_flutter_android/webview_flutter_android.dart';
 import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 
 class WebView extends StatefulWidget {
-  const WebView({Key? key}) : super(key: key);
+  const WebView({super.key});
 
   @override
   WebState createState() => WebState();
@@ -80,9 +80,9 @@ Page resource error:
       ..addJavaScriptChannel(
         'Toaster',
         onMessageReceived: (JavaScriptMessage message) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(message.message)),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(message.message)));
         },
       );
 
@@ -96,21 +96,23 @@ Page resource error:
 
     _controller = controller;
 
-    SahhaFlutter.getProfileToken().then((value) {
-      debugPrint(value);
-      if (value != null) {
-        controller.loadRequest(
-          Uri.parse("https://development.webview.sahha.ai/app"),
-          headers: {"Authorization": value},
-        );
-      } else {
-        controller.loadRequest(
-          Uri.parse("https://development.webview.sahha.ai/app"),
-        );
-      }
-    }).catchError((error, stackTrace) {
-      debugPrint(error.toString());
-    });
+    SahhaFlutter.getProfileToken()
+        .then((value) {
+          debugPrint(value);
+          if (value != null) {
+            controller.loadRequest(
+              Uri.parse("https://development.webview.sahha.ai/app"),
+              headers: {"Authorization": value},
+            );
+          } else {
+            controller.loadRequest(
+              Uri.parse("https://development.webview.sahha.ai/app"),
+            );
+          }
+        })
+        .catchError((error, stackTrace) {
+          debugPrint(error.toString());
+        });
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,9 +6,11 @@ import 'package:sahha_flutter_example/Views/HomeView.dart';
 import 'package:sahha_flutter_example/Views/ProfileView.dart';
 import 'package:sahha_flutter_example/Views/SamplesView.dart';
 import 'package:sahha_flutter_example/Views/ScoresView.dart';
+import 'package:sahha_flutter_example/Views/SensorDiagnosticsView.dart';
 import 'package:sahha_flutter_example/Views/SensorPermissionView.dart';
 import 'package:sahha_flutter_example/Views/StatsView.dart';
 import 'package:sahha_flutter_example/Views/WebView.dart';
+import 'package:sahha_flutter_example/theme.dart';
 
 void main() {
   runApp(const App());
@@ -27,13 +29,11 @@ class AppState extends State<App> {
     super.initState();
 
     // Use default values
-    SahhaFlutter.configure(
-      environment: SahhaEnvironment.sandbox
-    )
+    SahhaFlutter.configure(environment: SahhaEnvironment.sandbox)
         .then((success) => {debugPrint("Configure Success Result: $success")})
         .catchError((error, stackTrace) => {debugPrint(error.toString())});
 
-/*
+    /*
     // Android only
     var notificationSettings = {
       'icon': 'Custom Icon',
@@ -54,12 +54,17 @@ class AppState extends State<App> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      title: 'Sahha Demo',
+      theme: SahhaAppTheme.light(),
+      darkTheme: SahhaAppTheme.dark(),
+      themeMode: ThemeMode.system,
       initialRoute: '/',
       routes: <String, WidgetBuilder>{
         '/': (BuildContext context) => const HomeView(),
         '/authentication': (BuildContext context) => const AuthenticationView(),
         '/profile': (BuildContext context) => const ProfileView(),
         '/permissions': (BuildContext context) => const SensorPermissionView(),
+        '/diagnostics': (BuildContext context) => const SensorDiagnosticsView(),
         '/scores': (BuildContext context) => const ScoresView(),
         '/biomarkers': (BuildContext context) => const BiomarkersView(),
         '/stats': (BuildContext context) => const StatsView(),

--- a/example/lib/theme.dart
+++ b/example/lib/theme.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+
+/// Material 3 theming shared by every screen in the Sahha example app.
+///
+/// A single seed colour drives both brightnesses so screens only ever need
+/// `Theme.of(context).colorScheme` tokens instead of hard-coded colours.
+/// Semantic status colours (green / orange / red / grey) are the one
+/// deliberate exception and stay local to the screen that shows them.
+class SahhaAppTheme {
+  /// Deep violet seed — deliberately not the default Flutter blue so the test
+  /// harness is recognisable at a glance on a device full of demo apps.
+  static const Color seedColor = Color(0xFF4C2FD0);
+
+  /// Corner radius for cards and other large surfaces.
+  static const double cardRadius = 16;
+
+  /// Corner radius for smaller controls (inputs, buttons, tiles).
+  static const double controlRadius = 12;
+
+  /// Minimum height for the full-width action buttons used across the app.
+  static const double buttonHeight = 48;
+
+  static ThemeData light() => _themeFor(Brightness.light);
+
+  static ThemeData dark() => _themeFor(Brightness.dark);
+
+  static ThemeData _themeFor(Brightness brightness) {
+    final scheme = ColorScheme.fromSeed(
+      seedColor: seedColor,
+      brightness: brightness,
+    );
+    final base = ThemeData(useMaterial3: true, colorScheme: scheme);
+
+    final inputDecorationTheme = InputDecorationThemeData(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(controlRadius),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(controlRadius),
+        borderSide: BorderSide(color: scheme.outlineVariant),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(controlRadius),
+        borderSide: BorderSide(color: scheme.primary, width: 2),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(controlRadius),
+        borderSide: BorderSide(color: scheme.error),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(controlRadius),
+        borderSide: BorderSide(color: scheme.error, width: 2),
+      ),
+      labelStyle: TextStyle(color: scheme.onSurfaceVariant),
+      floatingLabelStyle: TextStyle(color: scheme.primary),
+    );
+
+    return base.copyWith(
+      scaffoldBackgroundColor: scheme.surface,
+      appBarTheme: AppBarThemeData(
+        elevation: 0,
+        scrolledUnderElevation: 2,
+        centerTitle: false,
+        backgroundColor: scheme.surface,
+        foregroundColor: scheme.onSurface,
+        surfaceTintColor: scheme.surfaceTint,
+        titleTextStyle: base.textTheme.titleLarge?.copyWith(
+          color: scheme.onSurface,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      cardTheme: CardThemeData(
+        elevation: 0,
+        margin: EdgeInsets.zero,
+        clipBehavior: Clip.antiAlias,
+        color: scheme.surfaceContainerLow,
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(cardRadius),
+          side: BorderSide(color: scheme.outlineVariant),
+        ),
+      ),
+      inputDecorationTheme: inputDecorationTheme,
+      dropdownMenuTheme: DropdownMenuThemeData(
+        inputDecorationTheme: inputDecorationTheme,
+        menuStyle: MenuStyle(
+          shape: WidgetStatePropertyAll(
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(controlRadius),
+            ),
+          ),
+        ),
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          minimumSize: const Size.fromHeight(buttonHeight),
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          textStyle: base.textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.4,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(controlRadius),
+          ),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          minimumSize: const Size.fromHeight(buttonHeight),
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          textStyle: base.textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.4,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(controlRadius),
+          ),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(controlRadius),
+          ),
+        ),
+      ),
+      listTileTheme: ListTileThemeData(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(controlRadius),
+        ),
+        iconColor: scheme.onSurfaceVariant,
+      ),
+      expansionTileTheme: ExpansionTileThemeData(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(cardRadius),
+          side: BorderSide(color: scheme.outlineVariant),
+        ),
+        collapsedShape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(cardRadius),
+          side: BorderSide(color: scheme.outlineVariant),
+        ),
+        childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        textColor: scheme.onSurface,
+        collapsedTextColor: scheme.onSurface,
+      ),
+      chipTheme: ChipThemeData(
+        side: BorderSide(color: scheme.outlineVariant),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
+      ),
+      dividerTheme: DividerThemeData(
+        space: 1,
+        thickness: 1,
+        color: scheme.outlineVariant,
+      ),
+      dialogTheme: DialogThemeData(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(cardRadius),
+        ),
+      ),
+      bottomSheetTheme: const BottomSheetThemeData(
+        showDragHandle: true,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(cardRadius)),
+        ),
+      ),
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(controlRadius),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/widgets/date_range_selector.dart
+++ b/example/lib/widgets/date_range_selector.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+/// Quick presets shown above the start/end tiles.
+enum DateRangePreset {
+  today('Today'),
+  yesterday('Yesterday'),
+  last24Hours('Last 24h'),
+  last7Days('Last 7 days'),
+  last30Days('Last 30 days');
+
+  const DateRangePreset(this.label);
+
+  final String label;
+
+  (DateTime, DateTime) resolve(DateTime now) {
+    final startOfToday = DateTime(now.year, now.month, now.day);
+    switch (this) {
+      case DateRangePreset.today:
+        return (startOfToday, now);
+      case DateRangePreset.yesterday:
+        return (startOfToday.subtract(const Duration(days: 1)), startOfToday);
+      case DateRangePreset.last24Hours:
+        return (now.subtract(const Duration(hours: 24)), now);
+      case DateRangePreset.last7Days:
+        return (now.subtract(const Duration(days: 7)), now);
+      case DateRangePreset.last30Days:
+        return (now.subtract(const Duration(days: 30)), now);
+    }
+  }
+}
+
+/// Shared start/end date-time controls for the query screens (Scores,
+/// Biomarkers, Stats, Samples): preset chips plus tappable tiles that open
+/// date and time pickers.
+class DateRangeSelector extends StatelessWidget {
+  const DateRangeSelector({
+    super.key,
+    required this.start,
+    required this.end,
+    required this.onChanged,
+  });
+
+  final DateTime start;
+  final DateTime end;
+  final void Function(DateTime start, DateTime end) onChanged;
+
+  static final DateFormat _dateTimeFormat = DateFormat('d MMM, HH:mm');
+
+  Future<void> _pick(BuildContext context, {required bool isStart}) async {
+    final current = isStart ? start : end;
+    final date = await showDatePicker(
+      context: context,
+      initialDate: current,
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now().add(const Duration(days: 1)),
+    );
+    if (date == null || !context.mounted) return;
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(current),
+    );
+    final picked = DateTime(
+      date.year,
+      date.month,
+      date.day,
+      time?.hour ?? current.hour,
+      time?.minute ?? current.minute,
+    );
+    if (isStart) {
+      onChanged(picked, picked.isAfter(end) ? picked : end);
+    } else {
+      onChanged(picked.isBefore(start) ? picked : start, picked);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Wrap(
+          spacing: 8,
+          children: [
+            for (final preset in DateRangePreset.values)
+              ActionChip(
+                label: Text(preset.label),
+                visualDensity: VisualDensity.compact,
+                onPressed: () {
+                  final (newStart, newEnd) = preset.resolve(DateTime.now());
+                  onChanged(newStart, newEnd);
+                },
+              ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: _DateTimeTile(
+                label: 'Start',
+                value: _dateTimeFormat.format(start),
+                onTap: () => _pick(context, isStart: true),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: _DateTimeTile(
+                label: 'End',
+                value: _dateTimeFormat.format(end),
+                onTap: () => _pick(context, isStart: false),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _DateTimeTile extends StatelessWidget {
+  const _DateTimeTile({
+    required this.label,
+    required this.value,
+    required this.onTap,
+  });
+
+  final String label;
+  final String value;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 12,
+            vertical: 10,
+          ),
+          suffixIcon: const Icon(Icons.edit_calendar_outlined, size: 18),
+        ),
+        child: Text(
+          value,
+          maxLines: 1,
+          overflow: TextOverflow.fade,
+          softWrap: false,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/widgets/multi_select_sheet.dart
+++ b/example/lib/widgets/multi_select_sheet.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+
+/// Generic searchable multi-select bottom sheet used for the long enum lists
+/// (biomarker types, sensors, score types).
+///
+/// Returns the new selection when applied, or null when dismissed.
+Future<Set<T>?> showMultiSelectSheet<T>({
+  required BuildContext context,
+  required String title,
+  required List<T> options,
+  required Set<T> initialSelection,
+  required String Function(T option) labelOf,
+  String Function(T option)? groupOf,
+}) {
+  return showModalBottomSheet<Set<T>>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    useSafeArea: true,
+    builder: (context) => DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.75,
+      minChildSize: 0.4,
+      maxChildSize: 0.95,
+      builder: (context, scrollController) => _MultiSelectSheet<T>(
+        title: title,
+        options: options,
+        initialSelection: initialSelection,
+        labelOf: labelOf,
+        groupOf: groupOf,
+        scrollController: scrollController,
+      ),
+    ),
+  );
+}
+
+class _MultiSelectSheet<T> extends StatefulWidget {
+  const _MultiSelectSheet({
+    required this.title,
+    required this.options,
+    required this.initialSelection,
+    required this.labelOf,
+    required this.groupOf,
+    required this.scrollController,
+  });
+
+  final String title;
+  final List<T> options;
+  final Set<T> initialSelection;
+  final String Function(T option) labelOf;
+  final String Function(T option)? groupOf;
+  final ScrollController scrollController;
+
+  @override
+  State<_MultiSelectSheet<T>> createState() => _MultiSelectSheetState<T>();
+}
+
+class _MultiSelectSheetState<T> extends State<_MultiSelectSheet<T>> {
+  late final Set<T> _selection = {...widget.initialSelection};
+  String _query = '';
+
+  List<T> get _filtered {
+    final query = _query.trim().toLowerCase();
+    if (query.isEmpty) return widget.options;
+    return widget.options
+        .where((o) => widget.labelOf(o).toLowerCase().contains(query))
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final filtered = _filtered;
+
+    // Group the filtered options; map literals preserve insertion order, so
+    // groups appear in first-seen order.
+    final grouped = <String?, List<T>>{};
+    for (final option in filtered) {
+      grouped.putIfAbsent(widget.groupOf?.call(option), () => []).add(option);
+    }
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(widget.title, style: theme.textTheme.titleMedium),
+                    Text(
+                      '${_selection.length} of ${widget.options.length} selected',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              TextButton(
+                onPressed: () => setState(() => _selection.addAll(filtered)),
+                child: const Text('All'),
+              ),
+              TextButton(
+                onPressed: () => setState(_selection.clear),
+                child: const Text('None'),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: TextField(
+            decoration: InputDecoration(
+              hintText: 'Search',
+              prefixIcon: const Icon(Icons.search, size: 20),
+              isDense: true,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+            onChanged: (value) => setState(() => _query = value),
+          ),
+        ),
+        const SizedBox(height: 8),
+        const Divider(height: 1),
+        Expanded(
+          child: ListView(
+            controller: widget.scrollController,
+            children: [
+              for (final entry in grouped.entries) ...[
+                if (entry.key != null)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
+                    child: Text(
+                      entry.key!,
+                      style: theme.textTheme.labelLarge?.copyWith(
+                        color: theme.colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                for (final option in entry.value)
+                  CheckboxListTile(
+                    dense: true,
+                    controlAffinity: ListTileControlAffinity.leading,
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 12),
+                    title: Text(widget.labelOf(option)),
+                    value: _selection.contains(option),
+                    onChanged: (checked) => setState(() {
+                      if (checked ?? false) {
+                        _selection.add(option);
+                      } else {
+                        _selection.remove(option);
+                      }
+                    }),
+                  ),
+              ],
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        SafeArea(
+          minimum: const EdgeInsets.fromLTRB(20, 12, 20, 12),
+          child: SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: () => Navigator.of(context).pop(_selection),
+              child: const Text('Apply'),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/widgets/response_sheet.dart
+++ b/example/lib/widgets/response_sheet.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Pretty prints [raw] when it contains valid JSON, otherwise returns the
+/// original string unchanged.
+String tryPrettyJson(String raw) {
+  try {
+    return const JsonEncoder.withIndent('  ').convert(jsonDecode(raw));
+  } catch (_) {
+    return raw;
+  }
+}
+
+/// Monospace style for JSON/API output.
+TextStyle monoStyle(BuildContext context, {double fontSize = 12}) {
+  return TextStyle(
+    fontFamily: Platform.isIOS ? 'Menlo' : 'monospace',
+    fontSize: fontSize,
+    height: 1.5,
+    color: Theme.of(context).colorScheme.onSurface,
+  );
+}
+
+/// Shows an API response (or error) in a draggable bottom sheet with a
+/// selectable monospace body and a copy button.
+Future<void> showResponseSheet(
+  BuildContext context, {
+  required String title,
+  required String body,
+  String? subtitle,
+  bool isError = false,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    useSafeArea: true,
+    builder: (sheetContext) {
+      return DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.6,
+        minChildSize: 0.3,
+        maxChildSize: 0.95,
+        builder: (context, scrollController) {
+          final theme = Theme.of(context);
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 8, 8),
+                child: Row(
+                  children: [
+                    Icon(
+                      isError
+                          ? Icons.error_outline
+                          : Icons.check_circle_outline,
+                      color: isError
+                          ? theme.colorScheme.error
+                          : theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(title, style: theme.textTheme.titleMedium),
+                          if (subtitle != null)
+                            Text(
+                              subtitle,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: 'Copy to clipboard',
+                      icon: const Icon(Icons.copy_outlined, size: 20),
+                      onPressed: () {
+                        Clipboard.setData(ClipboardData(text: body));
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Copied to clipboard')),
+                        );
+                      },
+                    ),
+                    IconButton(
+                      tooltip: 'Close',
+                      icon: const Icon(Icons.close, size: 20),
+                      onPressed: () => Navigator.of(sheetContext).pop(),
+                    ),
+                  ],
+                ),
+              ),
+              const Divider(height: 1),
+              Expanded(
+                child: SingleChildScrollView(
+                  controller: scrollController,
+                  padding: const EdgeInsets.all(20),
+                  child: Align(
+                    alignment: Alignment.topLeft,
+                    child: SelectableText(body, style: monoStyle(context)),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      );
+    },
+  );
+}

--- a/example/lib/widgets/sensor_groups.dart
+++ b/example/lib/widgets/sensor_groups.dart
@@ -1,0 +1,83 @@
+import 'package:sahha_flutter/sahha_flutter.dart';
+
+/// Buckets the long [SahhaSensor] enum into readable groups for pickers and
+/// the diagnostics screen.
+String sensorGroupOf(SahhaSensor sensor) {
+  if (sensor == SahhaSensor.gender || sensor == SahhaSensor.date_of_birth) {
+    return 'Demographic';
+  }
+  if (sensor.name.endsWith('_intake')) {
+    return 'Nutrition';
+  }
+  if (sensor.index >= SahhaSensor.abdominal_cramps.index) {
+    return 'Symptoms';
+  }
+  if (sensor.index >= SahhaSensor.menstrual_flow.index) {
+    return 'Reproductive';
+  }
+  if (sensor == SahhaSensor.sleep) {
+    return 'Sleep';
+  }
+  if (sensor == SahhaSensor.device_lock) {
+    return 'Device';
+  }
+  if (_activitySensors.contains(sensor)) {
+    return 'Activity & Mobility';
+  }
+  if (_bodySensors.contains(sensor)) {
+    return 'Body';
+  }
+  return 'Vitals';
+}
+
+/// Sensors in [SahhaSensor.values] order, sorted so that each group is
+/// contiguous (group order follows first appearance in the enum).
+List<SahhaSensor> sensorsGroupedInEnumOrder() {
+  final byGroup = <String, List<SahhaSensor>>{};
+  for (final sensor in SahhaSensor.values) {
+    byGroup.putIfAbsent(sensorGroupOf(sensor), () => []).add(sensor);
+  }
+  return [for (final group in byGroup.values) ...group];
+}
+
+const _activitySensors = <SahhaSensor>{
+  SahhaSensor.steps,
+  SahhaSensor.floors_climbed,
+  SahhaSensor.active_energy_burned,
+  SahhaSensor.basal_energy_burned,
+  SahhaSensor.total_energy_burned,
+  SahhaSensor.basal_metabolic_rate,
+  SahhaSensor.time_in_daylight,
+  SahhaSensor.stand_time,
+  SahhaSensor.move_time,
+  SahhaSensor.exercise_time,
+  SahhaSensor.activity_summary,
+  SahhaSensor.exercise,
+  SahhaSensor.running_speed,
+  SahhaSensor.running_power,
+  SahhaSensor.running_ground_contact_time,
+  SahhaSensor.running_stride_length,
+  SahhaSensor.running_vertical_oscillation,
+  SahhaSensor.six_minute_walk_test_distance,
+  SahhaSensor.stair_ascent_speed,
+  SahhaSensor.stair_descent_speed,
+  SahhaSensor.walking_speed,
+  SahhaSensor.walking_steadiness,
+  SahhaSensor.walking_asymmetry_percentage,
+  SahhaSensor.walking_double_support_percentage,
+  SahhaSensor.walking_step_length,
+};
+
+const _bodySensors = <SahhaSensor>{
+  SahhaSensor.height,
+  SahhaSensor.weight,
+  SahhaSensor.lean_body_mass,
+  SahhaSensor.body_mass_index,
+  SahhaSensor.body_fat,
+  SahhaSensor.body_water_mass,
+  SahhaSensor.bone_mass,
+  SahhaSensor.waist_circumference,
+  SahhaSensor.body_temperature,
+  SahhaSensor.basal_body_temperature,
+  SahhaSensor.sleeping_wrist_temperature,
+};

--- a/example/lib/widgets/sensor_picker.dart
+++ b/example/lib/widgets/sensor_picker.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:sahha_flutter/sahha_flutter.dart';
+import 'package:sahha_flutter_example/widgets/sensor_groups.dart';
+
+/// Searchable single-select bottom sheet over every [SahhaSensor].
+///
+/// Sensors are listed in [sensorsGroupedInEnumOrder] order with a header per
+/// [sensorGroupOf] group. Tapping a sensor pops the sheet and returns it;
+/// dismissing the sheet returns null.
+Future<SahhaSensor?> showSensorPicker(
+  BuildContext context, {
+  SahhaSensor? selected,
+}) {
+  return showModalBottomSheet<SahhaSensor>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    useSafeArea: true,
+    builder: (context) => DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.75,
+      minChildSize: 0.4,
+      maxChildSize: 0.95,
+      builder: (context, scrollController) => _SensorPickerSheet(
+        selected: selected,
+        scrollController: scrollController,
+      ),
+    ),
+  );
+}
+
+class _SensorPickerSheet extends StatefulWidget {
+  const _SensorPickerSheet({
+    required this.selected,
+    required this.scrollController,
+  });
+
+  final SahhaSensor? selected;
+  final ScrollController scrollController;
+
+  @override
+  State<_SensorPickerSheet> createState() => _SensorPickerSheetState();
+}
+
+class _SensorPickerSheetState extends State<_SensorPickerSheet> {
+  static final List<SahhaSensor> _options = sensorsGroupedInEnumOrder();
+
+  String _query = '';
+
+  List<SahhaSensor> get _filtered {
+    final query = _query.trim().toLowerCase();
+    if (query.isEmpty) return _options;
+    return _options
+        .where(
+          (sensor) =>
+              sensor.name.toLowerCase().contains(query) ||
+              sensorGroupOf(sensor).toLowerCase().contains(query),
+        )
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final filtered = _filtered;
+
+    // Group the filtered sensors, preserving first-seen group order.
+    final grouped = <String, List<SahhaSensor>>{};
+    for (final sensor in filtered) {
+      grouped.putIfAbsent(sensorGroupOf(sensor), () => []).add(sensor);
+    }
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Sensor', style: theme.textTheme.titleMedium),
+              Text(
+                '${filtered.length} of ${_options.length} sensors',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: TextField(
+            decoration: InputDecoration(
+              hintText: 'Search',
+              prefixIcon: const Icon(Icons.search, size: 20),
+              isDense: true,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+            onChanged: (value) => setState(() => _query = value),
+          ),
+        ),
+        const SizedBox(height: 8),
+        const Divider(height: 1),
+        Expanded(
+          child: filtered.isEmpty
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Text(
+                      'No sensors match "${_query.trim()}"',
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                )
+              : ListView(
+                  controller: widget.scrollController,
+                  children: [
+                    for (final entry in grouped.entries) ...[
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
+                        child: Text(
+                          entry.key,
+                          style: theme.textTheme.labelLarge?.copyWith(
+                            color: theme.colorScheme.primary,
+                          ),
+                        ),
+                      ),
+                      for (final sensor in entry.value)
+                        _SensorTile(
+                          sensor: sensor,
+                          isSelected: sensor == widget.selected,
+                        ),
+                    ],
+                    const SizedBox(height: 12),
+                  ],
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SensorTile extends StatelessWidget {
+  const _SensorTile({required this.sensor, required this.isSelected});
+
+  final SahhaSensor sensor;
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      dense: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+      selected: isSelected,
+      selectedTileColor: theme.colorScheme.primaryContainer.withValues(
+        alpha: 0.4,
+      ),
+      title: Text(sensor.name),
+      trailing: isSelected
+          ? Icon(Icons.check, size: 20, color: theme.colorScheme.primary)
+          : null,
+      onTap: () => Navigator.of(context).pop(sensor),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -160,14 +160,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -216,14 +208,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
-  provider:
-    dependency: transitive
-    description:
-      name: provider
-      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5+1"
   sahha_flutter:
     dependency: "direct main"
     description:
@@ -231,14 +215,6 @@ packages:
       relative: true
     source: path
     version: "1.4.0-beta.1"
-  selectpicker:
-    dependency: "direct main"
-    description:
-      name: selectpicker
-      sha256: b8a8c67c2079d56f88af9d6c6a3e077e3e6a74f268cb8821ea874103e7e460b4
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.6"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -381,7 +357,7 @@ packages:
     source: hosted
     version: "4.13.1"
   webview_flutter_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webview_flutter_android
       sha256: eeeb3fcd5f0ff9f8446c9f4bbc18a99b809e40297528a3395597d03aafb9f510
@@ -397,7 +373,7 @@ packages:
     source: hosted
     version: "2.14.0"
   webview_flutter_wkwebview:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
       sha256: e49f378ed066efb13fc36186bbe0bd2425630d4ea0dbc71a18fdd0e4d8ed8ebc

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -230,7 +230,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.9"
+    version: "1.4.0-beta.1"
   selectpicker:
     dependency: "direct main"
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -22,9 +22,13 @@ dependencies:
 
   intl: ^0.19.0
 
-  selectpicker: ^1.0.17
-
   webview_flutter: ^4.8.0
+
+  # Platform implementations are imported directly in WebView.dart for
+  # platform-specific configuration.
+  webview_flutter_android: ^4.10.0
+
+  webview_flutter_wkwebview: ^3.23.0
 
   sahha_flutter:
     # When depending on this package from a real application you should use:

--- a/ios/sahha_flutter.podspec
+++ b/ios/sahha_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sahha_flutter'
-  s.version          = '1.3.9'
+  s.version          = '1.4.0-beta.1'
   s.summary          = 'Sahha Flutter SDK'
   s.description      = 'The Sahha SDK provides a convenient way for Flutter apps to connect to the Sahha API.'
   s.homepage         = 'https://sahha.ai'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Sahha', '1.3.9'
+  s.dependency 'Sahha', '1.4.0-beta.1'
   s.platform = :ios, '15.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/sahha_flutter.dart
+++ b/lib/sahha_flutter.dart
@@ -171,7 +171,7 @@ enum SahhaBiomarkerType {
   active_hours,
   active_duration,
   activity_low_intensity_duration,
-  activity_mid_intensity_duration,
+  activity_medium_intensity_duration,
   activity_high_intensity_duration,
   activity_sedentary_duration,
   active_energy_burned,

--- a/lib/sahha_flutter.dart
+++ b/lib/sahha_flutter.dart
@@ -219,11 +219,10 @@ enum SahhaBiomarkerType {
 enum SahhaBiomarkerCategory {
   activity,
   body,
-  characteristic,
-  reproductive,
+  engagement,
+  nutrition,
   sleep,
   vitals,
-  nutrition
 }
 
 enum SahhaSensorStatus { pending, unavailable, disabled, enabled }

--- a/lib/sahha_flutter.dart
+++ b/lib/sahha_flutter.dart
@@ -431,6 +431,7 @@ static Future<SahhaSensorStatus> enableSensors(List<SahhaSensor> sensors) async 
     }
   }
 
+  @Deprecated('Use getBiomarkers to read server-processed biomarkers instead.')
   static Future<String> getStats(
       {required SahhaSensor sensor,
       required DateTime startDateTime,
@@ -451,6 +452,7 @@ static Future<SahhaSensorStatus> enableSensors(List<SahhaSensor> sensors) async 
     }
   }
 
+  @Deprecated('Use getBiomarkers to read server-processed biomarkers instead.')
   static Future<String> getSamples(
       {required SahhaSensor sensor,
       required DateTime startDateTime,

--- a/lib/sahha_flutter.dart
+++ b/lib/sahha_flutter.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
-enum SahhaEnvironment {  sandbox, production}
+enum SahhaEnvironment { sandbox, production }
 
 enum SahhaSensor {
   gender,
@@ -157,13 +157,7 @@ enum SahhaSensor {
   wheezing,
 }
 
-enum SahhaScoreType {
-  wellbeing,
-  activity,
-  sleep,
-  readiness,
-  mental_wellbeing,
-}
+enum SahhaScoreType { wellbeing, activity, sleep, readiness, mental_wellbeing }
 
 enum SahhaBiomarkerType {
   steps,
@@ -230,8 +224,11 @@ enum SahhaSensorStatus { pending, unavailable, disabled, enabled }
 class SahhaNotificationSettings {
   final String? icon, title, shortDescription;
 
-  const SahhaNotificationSettings(
-      {this.icon, this.title, this.shortDescription});
+  const SahhaNotificationSettings({
+    this.icon,
+    this.title,
+    this.shortDescription,
+  });
 }
 
 class SahhaFlutter {
@@ -240,7 +237,7 @@ class SahhaFlutter {
   static Future<bool> configure({
     required SahhaEnvironment environment,
     Map<String, String> notificationSettings = const <String, String>{},
-    bool enableMotionTrigger = false, 
+    bool enableMotionTrigger = false,
   }) async {
     try {
       final bool success = await _channel.invokeMethod('configure', {
@@ -256,7 +253,6 @@ class SahhaFlutter {
     }
   }
 
-
   static Future<bool> isAuthenticated() async {
     try {
       bool success = await _channel.invokeMethod('isAuthenticated');
@@ -268,13 +264,17 @@ class SahhaFlutter {
     }
   }
 
-  static Future<bool> authenticate(
-      {required String appId,
-      required String appSecret,
-      required String externalId}) async {
+  static Future<bool> authenticate({
+    required String appId,
+    required String appSecret,
+    required String externalId,
+  }) async {
     try {
-      bool success = await _channel.invokeMethod('authenticate',
-          {'appId': appId, 'appSecret': appSecret, 'externalId': externalId});
+      bool success = await _channel.invokeMethod('authenticate', {
+        'appId': appId,
+        'appSecret': appSecret,
+        'externalId': externalId,
+      });
       return success;
     } on PlatformException catch (error) {
       return Future.error(error);
@@ -283,11 +283,15 @@ class SahhaFlutter {
     }
   }
 
-  static Future<bool> authenticateToken(
-      {required String profileToken, required String refreshToken}) async {
+  static Future<bool> authenticateToken({
+    required String profileToken,
+    required String refreshToken,
+  }) async {
     try {
-      bool success = await _channel.invokeMethod('authenticateToken',
-          {'profileToken': profileToken, 'refreshToken': refreshToken});
+      bool success = await _channel.invokeMethod('authenticateToken', {
+        'profileToken': profileToken,
+        'refreshToken': refreshToken,
+      });
       return success;
     } on PlatformException catch (error) {
       return Future.error(error);
@@ -331,8 +335,10 @@ class SahhaFlutter {
 
   static Future<bool> postDemographic(Map demographic) async {
     try {
-      bool success =
-          await _channel.invokeMethod('postDemographic', demographic);
+      bool success = await _channel.invokeMethod(
+        'postDemographic',
+        demographic,
+      );
       return success;
     } on PlatformException catch (error) {
       return Future.error(error);
@@ -341,40 +347,46 @@ class SahhaFlutter {
     }
   }
 
-static Future<SahhaSensorStatus> getSensorStatus(List<SahhaSensor> sensors) async {
-  try {
-    final sensorStrings = sensors.map((s) => s.name).toList();
-    final raw = await _channel.invokeMethod('getSensorStatus', {'sensors': sensorStrings});
-    return _statusFromNative(raw);
-  } on PlatformException catch (error) {
-    return Future.error(error);
-  } catch (error) {
-    return Future.error(error);
+  static Future<SahhaSensorStatus> getSensorStatus(
+    List<SahhaSensor> sensors,
+  ) async {
+    try {
+      final sensorStrings = sensors.map((s) => s.name).toList();
+      final raw = await _channel.invokeMethod('getSensorStatus', {
+        'sensors': sensorStrings,
+      });
+      return _statusFromNative(raw);
+    } on PlatformException catch (error) {
+      return Future.error(error);
+    } catch (error) {
+      return Future.error(error);
+    }
   }
-}
 
-
-static SahhaSensorStatus _statusFromNative(dynamic raw) {
-  final name = raw.toString().trim().toLowerCase();
-  // Unknown/future statuses (e.g. iOS "indeterminate") fall back to pending.
-  return SahhaSensorStatus.values.firstWhere(
-    (e) => e.name == name,
-    orElse: () => SahhaSensorStatus.pending,
-  );
-}
-
-static Future<SahhaSensorStatus> enableSensors(List<SahhaSensor> sensors) async {
-  try {
-    final sensorStrings = sensors.map((s) => s.name).toList();
-    final raw = await _channel.invokeMethod('enableSensors', {'sensors': sensorStrings});
-    return _statusFromNative(raw);
-  } on PlatformException catch (error) {
-    return Future.error(error);
-  } catch (error) {
-    return Future.error(error);
+  static SahhaSensorStatus _statusFromNative(dynamic raw) {
+    final name = raw.toString().trim().toLowerCase();
+    // Unknown/future statuses (e.g. iOS "indeterminate") fall back to pending.
+    return SahhaSensorStatus.values.firstWhere(
+      (e) => e.name == name,
+      orElse: () => SahhaSensorStatus.pending,
+    );
   }
-}
 
+  static Future<SahhaSensorStatus> enableSensors(
+    List<SahhaSensor> sensors,
+  ) async {
+    try {
+      final sensorStrings = sensors.map((s) => s.name).toList();
+      final raw = await _channel.invokeMethod('enableSensors', {
+        'sensors': sensorStrings,
+      });
+      return _statusFromNative(raw);
+    } on PlatformException catch (error) {
+      return Future.error(error);
+    } catch (error) {
+      return Future.error(error);
+    }
+  }
 
   static void postSensorData() {
     _channel.invokeMethod('postSensorData');
@@ -384,10 +396,11 @@ static Future<SahhaSensorStatus> enableSensors(List<SahhaSensor> sensors) async 
     _channel.invokeMethod('openAppSettings');
   }
 
-  static Future<String> getScores(
-      {required List<SahhaScoreType> types,
-      required DateTime startDateTime,
-      required DateTime endDateTime}) async {
+  static Future<String> getScores({
+    required List<SahhaScoreType> types,
+    required DateTime startDateTime,
+    required DateTime endDateTime,
+  }) async {
     try {
       List<String> scoreTypeStrings = types.map((type) => type.name).toList();
       int startDateInt = startDateTime.millisecondsSinceEpoch;
@@ -395,7 +408,7 @@ static Future<SahhaSensorStatus> enableSensors(List<SahhaSensor> sensors) async 
       String value = await _channel.invokeMethod('getScores', {
         'types': scoreTypeStrings,
         'startDateTime': startDateInt,
-        'endDateTime': endDateInt
+        'endDateTime': endDateInt,
       });
       return value;
     } on PlatformException catch (error) {
@@ -405,23 +418,26 @@ static Future<SahhaSensorStatus> enableSensors(List<SahhaSensor> sensors) async 
     }
   }
 
-  static Future<String> getBiomarkers(
-      {required List<SahhaBiomarkerCategory> categories,
-      required List<SahhaBiomarkerType> types,
-      required DateTime startDateTime,
-      required DateTime endDateTime}) async {
+  static Future<String> getBiomarkers({
+    required List<SahhaBiomarkerCategory> categories,
+    required List<SahhaBiomarkerType> types,
+    required DateTime startDateTime,
+    required DateTime endDateTime,
+  }) async {
     try {
-      List<String> biomarkerCategoryStrings =
-          categories.map((category) => category.name).toList();
-      List<String> biomarkerTypeStrings =
-          types.map((type) => type.name).toList();
+      List<String> biomarkerCategoryStrings = categories
+          .map((category) => category.name)
+          .toList();
+      List<String> biomarkerTypeStrings = types
+          .map((type) => type.name)
+          .toList();
       int startDateInt = startDateTime.millisecondsSinceEpoch;
       int endDateInt = endDateTime.millisecondsSinceEpoch;
       String value = await _channel.invokeMethod('getBiomarkers', {
         'categories': biomarkerCategoryStrings,
         'types': biomarkerTypeStrings,
         'startDateTime': startDateInt,
-        'endDateTime': endDateInt
+        'endDateTime': endDateInt,
       });
       return value;
     } on PlatformException catch (error) {
@@ -432,17 +448,18 @@ static Future<SahhaSensorStatus> enableSensors(List<SahhaSensor> sensors) async 
   }
 
   @Deprecated('Use getBiomarkers to read server-processed biomarkers instead.')
-  static Future<String> getStats(
-      {required SahhaSensor sensor,
-      required DateTime startDateTime,
-      required DateTime endDateTime}) async {
+  static Future<String> getStats({
+    required SahhaSensor sensor,
+    required DateTime startDateTime,
+    required DateTime endDateTime,
+  }) async {
     try {
       int startDateInt = startDateTime.millisecondsSinceEpoch;
       int endDateInt = endDateTime.millisecondsSinceEpoch;
       String stats = await _channel.invokeMethod('getStats', {
         'sensor': sensor.name,
         'startDateTime': startDateInt,
-        'endDateTime': endDateInt
+        'endDateTime': endDateInt,
       });
       return stats;
     } on PlatformException catch (error) {
@@ -453,17 +470,18 @@ static Future<SahhaSensorStatus> enableSensors(List<SahhaSensor> sensors) async 
   }
 
   @Deprecated('Use getBiomarkers to read server-processed biomarkers instead.')
-  static Future<String> getSamples(
-      {required SahhaSensor sensor,
-      required DateTime startDateTime,
-      required DateTime endDateTime}) async {
+  static Future<String> getSamples({
+    required SahhaSensor sensor,
+    required DateTime startDateTime,
+    required DateTime endDateTime,
+  }) async {
     try {
       int startDateInt = startDateTime.millisecondsSinceEpoch;
       int endDateInt = endDateTime.millisecondsSinceEpoch;
       String samples = await _channel.invokeMethod('getSamples', {
         'sensor': sensor.name,
         'startDateTime': startDateInt,
-        'endDateTime': endDateInt
+        'endDateTime': endDateInt,
       });
       return samples;
     } on PlatformException catch (error) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sahha_flutter
 description: Sahha Flutter Plugin
-version: 1.3.9
+version: 1.4.0-beta.1
 homepage: https://sahha.ai
 repository: https://github.com/sahha-ai/sahha_flutter
 


### PR DESCRIPTION
### Added

- `engagement` biomarker category in `SahhaBiomarkerCategory`.

### Changed

- **Breaking:** `SahhaBiomarkerCategory` now contains exactly the six documented categories (`activity`, `body`, `engagement`, `nutrition`, `sleep`, `vitals`). Removed `characteristic` and `reproductive`, which never returned biomarker data.
- **Breaking:** renamed `SahhaBiomarkerType.activity_mid_intensity_duration` to `activity_medium_intensity_duration`. The old name was outside the documented vocabulary and silently returned no data.
- Deprecated `getStats` and `getSamples` — use `getBiomarkers` to read server-processed biomarkers instead.
- Stat and sample `category` values are now labeled with the sensor's data-log logType (`heart`, `blood`, `oxygen`, `temperature`, `energy`); `vitals` no longer appears.
- Rebuilt the example app as a full testing harness — biomarker, score, stats and samples query screens with type selectors and date ranges, a checked-list sensor permissions screen, a per-sensor diagnostics screen, and a Material 3 UI.
- Updated iOS to 1.4.0-beta.1 — release notes: https://github.com/sahha-ai/sahha-ios/releases
- Updated Android to 1.4.0-beta.1 — release notes: https://github.com/sahha-ai/sahha-android-sdk/releases

### Fixed

- iOS: `enableSensors` callback no longer hangs indefinitely; hardened token refresh and session-expiry handling.
- Android: `enableSensors` reports sensor status reliably, skips unknown biomarker names in the bridge instead of crashing, and picks up Health Connect read-robustness fixes from the native 1.4.0-beta.1 release.
