### PR TITLE
fix: update to 1.4.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.4.0-beta.2
+
+### Added
+
+-
+
+### Changed
+
+- Updated iOS to 1.4.0-beta.2 — check release notes https://github.com/sahha-ai/sahha-ios/releases
+- Updated Android to 1.4.0-beta.2 — check release notes https://github.com/sahha-ai/sahha-android-sdk/releases
+
+### Fixed
+
+- Android: `getSamples` for steps no longer returns empty or partial results — step queries previously shared the background upload pipeline's de-duplication state, hiding records already collected by sync (fixed in the native 1.4.0-beta.2 release).
+
+---
+
 ## 1.4.0-beta.1
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,5 +54,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.google.code.gson:gson:2.13.2"
-    implementation "ai.sahha.android:sahha-api:1.4.0-beta.1"
+    implementation "ai.sahha.android:sahha-api:1.4.0-beta.2"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Sahha (1.4.0-beta.1)
-  - sahha_flutter (1.4.0-beta.1):
+  - Sahha (1.4.0-beta.2)
+  - sahha_flutter (1.4.0-beta.2):
     - Flutter
-    - Sahha (= 1.4.0-beta.1)
+    - Sahha (= 1.4.0-beta.2)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  Sahha: 62e9ceca5431682ddfc55fd5768ebf8c63e84e3f
-  sahha_flutter: 95bbf357e431eecc164d09d6a61f7e1fdcc7bb52
+  Sahha: 4c76bc33ab9e1e1e6f7800e3b400c8887df96961
+  sahha_flutter: 593d8d998464d133e4fa307be5a2894e5e77f39e
 
 PODFILE CHECKSUM: 3e9409b67ba5801961716bfaf81c42bfee93d9a9
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -214,7 +214,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.0-beta.1"
+    version: "1.4.0-beta.2"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/ios/sahha_flutter.podspec
+++ b/ios/sahha_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sahha_flutter'
-  s.version          = '1.4.0-beta.1'
+  s.version          = '1.4.0-beta.2'
   s.summary          = 'Sahha Flutter SDK'
   s.description      = 'The Sahha SDK provides a convenient way for Flutter apps to connect to the Sahha API.'
   s.homepage         = 'https://sahha.ai'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Sahha', '1.4.0-beta.1'
+  s.dependency 'Sahha', '1.4.0-beta.2'
   s.platform = :ios, '15.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sahha_flutter
 description: Sahha Flutter Plugin
-version: 1.4.0-beta.1
+version: 1.4.0-beta.2
 homepage: https://sahha.ai
 repository: https://github.com/sahha-ai/sahha_flutter
 


### PR DESCRIPTION
### Added

-

### Changed

- Updated iOS to 1.4.0-beta.2 — check release notes https://github.com/sahha-ai/sahha-ios/releases
- Updated Android to 1.4.0-beta.2 — check release notes https://github.com/sahha-ai/sahha-android-sdk/releases

### Fixed

- Android: `getSamples` for steps no longer returns empty or partial results — step queries previously shared the background upload pipeline's de-duplication state, hiding records already collected by sync (fixed in the native 1.4.0-beta.2 release).
