### PR TITLE
fix: update to 1.4.0

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -73,9 +73,9 @@ A git guardrail blocks Claude from pushing/force-pushing `main` and `development
 - pub.dev publish is IRREVERSIBLE (retract only within 7 days, version never reusable). Get explicit user confirmation, then run `flutter pub publish --force`.
 - Betas publish as prereleases (stable stays "latest").
 
-## 9. GitHub Release (stable only)
-- For a STABLE `x.y.z`: create a GitHub Release — `gh release create $1 --title "$1" --notes "<this version's changelog section>"`.
-- For a beta/prerelease: skip the GitHub Release (this repo only cuts GitHub Releases for stable versions).
+## 9. GitHub Release (every version)
+- Create a GitHub Release for every version — `gh release create $1 --title "$1" --notes "<this version's changelog section>"` (notes = the changelog section without the `## $1` heading).
+- For a beta/prerelease, add `--prerelease` (matches how sahha-ios and sahha-android-sdk mark their betas). Stable releases stay "latest".
 
 ## 10. Wrap up
 - Summarize what shipped + the pub.dev URL (`https://pub.dev/packages/sahha_flutter/versions/$1`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 1.4.0
+
+Stable release of the 1.4.0 line, consolidating the 1.4.0-beta.1 and 1.4.0-beta.2 changes with the final native 1.4.0 SDKs.
+
+### Added
+
+- `engagement` biomarker category in `SahhaBiomarkerCategory`.
+- Android: skipped unreadable Health Connect records are now reported to Sahha error telemetry, so affected devices are visible without device logs.
+
+### Changed
+
+- **Breaking:** `SahhaBiomarkerCategory` now contains exactly the six documented categories (`activity`, `body`, `engagement`, `nutrition`, `sleep`, `vitals`). Removed `characteristic` and `reproductive`, which never returned biomarker data.
+- **Breaking:** renamed `SahhaBiomarkerType.activity_mid_intensity_duration` to `activity_medium_intensity_duration`, matching the server vocabulary — the old name always returned no data.
+- Deprecated `getStats` and `getSamples` — use `getBiomarkers` to read server-processed biomarkers instead.
+- Stat and sample `category` values now carry the sensor's data-log logType — the same label stamped on uploaded data on both platforms: heart rate types report `heart`, blood pressure/glucose report `blood`, oxygen/VO2 max/respiratory rate report `oxygen`, temperature types report `temperature`, and energy/daylight types report `energy`. `vitals` no longer appears.
+- Rebuilt the example app as a full SDK testing harness.
+- Updated iOS to 1.4.0 — check release notes https://github.com/sahha-ai/sahha-ios/releases
+- Updated Android to 1.4.0 — check release notes https://github.com/sahha-ai/sahha-android-sdk/releases
+
+### Fixed
+
+- iOS: sensor sets with no HealthKit-backed types (such as `device_lock` alone, or Android-only sensors) no longer make permission requests throw "Health data types not specified" — requesting permissions now succeeds as a no-op and sensor status reports correctly through the normal lifecycle.
+- iOS: `enableSensors` no longer risks hanging indefinitely without invoking its callback; profile token refresh and session-expiry handling are hardened against transient network and server errors.
+- Android: `enableSensors` reports the real sensor status reliably (the native callback now returns a `SahhaSensorStatus`).
+- Android: eliminated phantom step spikes caused by step-counter regressions and implausible jumps; reboots are detected reliably, and steps recorded during collection outages are recovered.
+- Android: Health Connect reads now step around records the client library cannot parse instead of dropping the surrounding data, and an interrupted read no longer advances the sync marker past unread data.
+- Android: `getSamples` for steps no longer returns empty or partial results after background sync has run, and queries no longer interfere with upload de-duplication.
+- Android: device-lock events are now stamped with the correct phone form factor.
+
+---
+
 ## 1.4.0-beta.2
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,5 +54,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.google.code.gson:gson:2.13.2"
-    implementation "ai.sahha.android:sahha-api:1.4.0-beta.2"
+    implementation "ai.sahha.android:sahha-api:1.4.0"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Flutter (1.0.0)
-  - Sahha (1.4.0-beta.2)
-  - sahha_flutter (1.4.0-beta.2):
+  - Sahha (1.4.0)
+  - sahha_flutter (1.4.0):
     - Flutter
-    - Sahha (= 1.4.0-beta.2)
+    - Sahha (= 1.4.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  Sahha: 4c76bc33ab9e1e1e6f7800e3b400c8887df96961
-  sahha_flutter: 593d8d998464d133e4fa307be5a2894e5e77f39e
+  Sahha: f0017b5a48a4e8c0981e8af8528eea097c9bbd0f
+  sahha_flutter: fcf82f5f4d3c75c2bb4e317e9f8701374cbb2ddb
 
 PODFILE CHECKSUM: 3e9409b67ba5801961716bfaf81c42bfee93d9a9
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -214,7 +214,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.0-beta.2"
+    version: "1.4.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/ios/sahha_flutter.podspec
+++ b/ios/sahha_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'sahha_flutter'
-  s.version          = '1.4.0-beta.2'
+  s.version          = '1.4.0'
   s.summary          = 'Sahha Flutter SDK'
   s.description      = 'The Sahha SDK provides a convenient way for Flutter apps to connect to the Sahha API.'
   s.homepage         = 'https://sahha.ai'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Sahha', '1.4.0-beta.2'
+  s.dependency 'Sahha', '1.4.0'
   s.platform = :ios, '15.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sahha_flutter
 description: Sahha Flutter Plugin
-version: 1.4.0-beta.2
+version: 1.4.0
 homepage: https://sahha.ai
 repository: https://github.com/sahha-ai/sahha_flutter
 


### PR DESCRIPTION
Stable release of the 1.4.0 line, consolidating the 1.4.0-beta.1 and 1.4.0-beta.2 changes with the final native 1.4.0 SDKs.

### Added

- `engagement` biomarker category in `SahhaBiomarkerCategory`.
- Android: skipped unreadable Health Connect records are now reported to Sahha error telemetry, so affected devices are visible without device logs.

### Changed

- **Breaking:** `SahhaBiomarkerCategory` now contains exactly the six documented categories (`activity`, `body`, `engagement`, `nutrition`, `sleep`, `vitals`). Removed `characteristic` and `reproductive`, which never returned biomarker data.
- **Breaking:** renamed `SahhaBiomarkerType.activity_mid_intensity_duration` to `activity_medium_intensity_duration`, matching the server vocabulary — the old name always returned no data.
- Deprecated `getStats` and `getSamples` — use `getBiomarkers` to read server-processed biomarkers instead.
- Stat and sample `category` values now carry the sensor's data-log logType — the same label stamped on uploaded data on both platforms: heart rate types report `heart`, blood pressure/glucose report `blood`, oxygen/VO2 max/respiratory rate report `oxygen`, temperature types report `temperature`, and energy/daylight types report `energy`. `vitals` no longer appears.
- Rebuilt the example app as a full SDK testing harness.
- Updated iOS to 1.4.0 — check release notes https://github.com/sahha-ai/sahha-ios/releases
- Updated Android to 1.4.0 — check release notes https://github.com/sahha-ai/sahha-android-sdk/releases

### Fixed

- iOS: sensor sets with no HealthKit-backed types (such as `device_lock` alone, or Android-only sensors) no longer make permission requests throw "Health data types not specified" — requesting permissions now succeeds as a no-op and sensor status reports correctly through the normal lifecycle.
- iOS: `enableSensors` no longer risks hanging indefinitely without invoking its callback; profile token refresh and session-expiry handling are hardened against transient network and server errors.
- Android: `enableSensors` reports the real sensor status reliably (the native callback now returns a `SahhaSensorStatus`).
- Android: eliminated phantom step spikes caused by step-counter regressions and implausible jumps; reboots are detected reliably, and steps recorded during collection outages are recovered.
- Android: Health Connect reads now step around records the client library cannot parse instead of dropping the surrounding data, and an interrupted read no longer advances the sync marker past unread data.
- Android: `getSamples` for steps no longer returns empty or partial results after background sync has run, and queries no longer interfere with upload de-duplication.
- Android: device-lock events are now stamped with the correct phone form factor.
